### PR TITLE
Hash for u128 timestamp tuple

### DIFF
--- a/types/src/cryptography/hash.rs
+++ b/types/src/cryptography/hash.rs
@@ -1,3 +1,4 @@
+use crate::Timestamp;
 use alloy_primitives::Address;
 pub use alloy_primitives::{keccak256 as hash, B256 as Hash};
 use bytes::Bytes;
@@ -22,6 +23,27 @@ impl Hashable for Bytes {
 impl Hashable for Address {
     fn hash_custom(&self) -> Hash {
         hash(self.0)
+    }
+}
+
+impl Hashable for u128 {
+    fn hash_custom(&self) -> Hash {
+        hash(self.to_be_bytes())
+    }
+}
+
+impl Hashable for Timestamp {
+    fn hash_custom(&self) -> Hash {
+        hash(self.as_micros().to_be_bytes())
+    }
+}
+
+impl Hashable for (u128, Timestamp) {
+    fn hash_custom(&self) -> Hash {
+        let mut bytes = [0u8; 32];
+        bytes[..16].copy_from_slice(&self.0.to_be_bytes());
+        bytes[16..].copy_from_slice(&self.1.as_micros().to_be_bytes());
+        hash(bytes)
     }
 }
 


### PR DESCRIPTION
This PR adds a `hash_custom` for:

* `u128`
* `Timestamp`
* `(u128, Timestamp)`