### PR TITLE
refactor and cleanup PodProvider and its builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,14 +2370,11 @@ dependencies = [
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-types",
- "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
  "alloy-transport",
- "alloy-transport-http",
  "anyhow",
- "async-trait",
  "futures",
  "hex",
  "pod-contracts",
@@ -2385,6 +2382,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-test",
 ]
 
 [[package]]
@@ -3349,6 +3347,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -27,18 +27,19 @@ alloy-signer-local = "0.9.2"
 alloy-sol-types = "0.8.24"
 alloy-network = "0.9.2"
 futures = "0.3.31"
-async-trait = "0.1.86"
 alloy-consensus = "0.9.2"
-alloy-provider = { version = "0.9.2", features = ["pubsub", "ws"] }
+alloy-provider = { version = "0.9.2", features = ["pubsub", "ws", "reqwest"] }
 alloy-pubsub = "0.9.2"
 thiserror = "2.0.11"
 
-alloy-rpc-types-eth = "0.9.2"
-
 alloy-eips = "0.9.2"
 anyhow = "1.0.95"
-alloy-transport-http = "0.9.2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 hex = "0.4.3"
+tokio-test = "0.4.4"
+
+[package.metadata.cargo-shear]
+# tokio-test is used in doctests
+ignored = ["tokio-test"]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -1,3 +1,58 @@
+//! A Rust SDK for interacting with pod network.
+//!
+//! # Usage
+//!
+//! First, add this to your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! pod-sdk = "0.1.0"
+//! ```
+//!
+//! ## Querying account balance
+//!
+//! ```no_run
+//! use std::str::FromStr;
+//! use pod_sdk::{Address, Provider, provider::PodProviderBuilder};
+//!
+//! let rpc_url = "ws://localhost:8545";
+//! let account = Address::from_str("0xC7096D019F96faE581361aFB07311cd6D3a25596").unwrap();
+//!
+//! # tokio_test::block_on(async {
+//! let pod_provider = PodProviderBuilder::new().on_url(rpc_url).await.unwrap();
+//! pod_provider.get_balance(account).await.unwrap();
+//! # })
+//! ```
+//!
+//! ## Sending a transfer
+//!
+//! ```no_run
+//! use std::str::FromStr;
+//! use pod_sdk::{Address, EthereumWallet, provider::PodProviderBuilder, PrivateKeySigner, SigningKey, U256};
+//!
+//! let rpc_url = "ws://localhost:8545";
+//! let private_key_bytes = hex::decode("9a3f1b8475d296f2e7c1a3d5986b34c7f4de1bc2093a60f8be4f7dcaa12389ef").unwrap();
+//! let private_key = SigningKey::from_slice(&private_key_bytes).unwrap();
+//! let signer = PrivateKeySigner::from_signing_key(private_key);
+//! let wallet = EthereumWallet::new(signer);
+//!
+//! let to = Address::from_str("0xC7096D019F96faE581361aFB07311cd6D3a25596").unwrap();
+//! let amount = U256::from(1000);
+//!
+//! # tokio_test::block_on(async {
+//! // `with_recommended_settings` sets it up to fill gas, nonce and chain ID automatically
+//! let pod_provider = PodProviderBuilder::with_recommended_settings()
+//!      // pass wallet to send funds from and to sign the transaction
+//!     .wallet(wallet)
+//!     // An URL to a fullnode RPC API
+//!     .on_url(rpc_url)
+//!     .await
+//!     .unwrap();
+//!
+//! pod_provider.transfer(to, amount).await.unwrap();
+//! # })
+//! ```
+
 pub mod network;
 pub mod provider;
 pub mod types;
@@ -12,7 +67,14 @@ pub use alloy_consensus::TxLegacy;
 pub use alloy_network::{EthereumWallet, TransactionBuilder};
 pub use alloy_primitives::{Address, Bytes, TxKind, U256};
 pub use alloy_provider::{Provider, ProviderBuilder};
+pub use alloy_signer::k256::ecdsa::SigningKey;
 pub use alloy_signer_local::PrivateKeySigner;
+
+// Re-export external dependency crates
+pub use alloy_primitives;
+pub use alloy_rpc_types;
+pub use alloy_signer;
+pub use alloy_sol_types;
 
 // Re-export types types used in public API
 pub use pod_types::{

--- a/sdk/src/network/mod.rs
+++ b/sdk/src/network/mod.rs
@@ -8,13 +8,12 @@ use alloy_primitives::{Address, B256, BlockHash, Bytes, ChainId, Log, TxHash, Tx
 use alloy_provider::fillers::{
     ChainIdFiller, GasFiller, JoinFill, NonceFiller, RecommendedFillers,
 };
-use alloy_rpc_types_eth::TransactionRequest;
 
 use anyhow::Result;
 use pod_types::ledger::Transaction;
 
 use alloy_consensus::TxEnvelope;
-use alloy_rpc_types::TransactionReceipt;
+use alloy_rpc_types::{TransactionReceipt, TransactionRequest};
 use pod_types::{
     Committee, Hashable, Merkleizable, Receipt, Signed, Timestamp,
     ecdsa::{AddressECDSA, SignatureECDSA},
@@ -361,10 +360,10 @@ impl Network for PodNetwork {
     type ReceiptEnvelope = alloy_consensus::ReceiptEnvelope;
     type Header = alloy_consensus::Header;
     type TransactionRequest = PodTransactionRequest;
-    type TransactionResponse = alloy_rpc_types_eth::Transaction;
+    type TransactionResponse = alloy_rpc_types::Transaction;
     type ReceiptResponse = PodReceiptResponse;
-    type HeaderResponse = alloy_rpc_types_eth::Header;
-    type BlockResponse = alloy_rpc_types_eth::Block;
+    type HeaderResponse = alloy_rpc_types::Header;
+    type BlockResponse = alloy_rpc_types::Block;
 }
 
 impl RecommendedFillers for PodNetwork {

--- a/sdk/src/provider/mod.rs
+++ b/sdk/src/provider/mod.rs
@@ -1,10 +1,17 @@
-use crate::network::{PodNetwork, PodReceiptResponse};
+use std::sync::Arc;
+
+pub use alloy_provider;
+
+use crate::network::{PodNetwork, PodReceiptResponse, PodTransactionRequest};
 use alloy_json_rpc::{RpcParam, RpcReturn};
-use alloy_network::Network;
-use alloy_provider::{Identity, Provider, ProviderBuilder};
+use alloy_network::{Network, TransactionBuilder};
+use alloy_provider::{
+    Identity, Provider, ProviderBuilder, ProviderLayer, RootProvider,
+    fillers::{JoinFill, RecommendedFillers, TxFiller, WalletFiller},
+};
 use alloy_pubsub::Subscription;
-use alloy_rpc_types_eth::Filter;
-use alloy_transport::{Transport, TransportResult};
+
+use alloy_transport::{BoxTransport, Transport, TransportError, TransportResult};
 use futures::StreamExt;
 use pod_types::{
     consensus::Committee,
@@ -12,7 +19,7 @@ use pod_types::{
     pagination::{ApiPaginatedResult, CursorPaginationRequest},
 };
 
-use alloy_primitives::{Address, B256 as Hash, Log};
+use alloy_primitives::{Address, B256 as Hash, Log, U256};
 
 use pod_types::Timestamp;
 use serde::{Deserialize, Serialize};
@@ -27,12 +34,78 @@ impl CommitteeResponse {
     }
 }
 
-pub struct PodProviderBuilder;
+pub struct PodProviderBuilder<L, F>(ProviderBuilder<L, F, PodNetwork>);
 
-impl PodProviderBuilder {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> ProviderBuilder<Identity, Identity, PodNetwork> {
-        ProviderBuilder::new().network::<PodNetwork>()
+/// Create a PodProviderBuilder set up with recommended settings.
+///
+/// The builder can be used to build a [Provider] configured for the [PodNetwork].
+///
+/// The returned builder has fillers preconfigured to automatically fill
+/// chain ID, nonce and gas price. Check [PodNetwork::RecommendedFillers] for details.
+impl
+    PodProviderBuilder<
+        Identity,
+        JoinFill<Identity, <PodNetwork as RecommendedFillers>::RecommendedFillers>,
+    >
+{
+    pub fn with_recommended_settings() -> Self {
+        Self(PodProviderBuilder::default().0.with_recommended_fillers())
+    }
+}
+
+impl Default for PodProviderBuilder<Identity, Identity> {
+    fn default() -> Self {
+        Self(ProviderBuilder::new().network::<PodNetwork>())
+    }
+}
+
+impl PodProviderBuilder<Identity, Identity> {
+    pub fn new() -> Self {
+        PodProviderBuilder::<Identity, Identity>::default()
+    }
+}
+
+impl<L, F> PodProviderBuilder<L, F> {
+    /// Finish the layer stack by providing a url for connection,
+    /// outputting the final [`PodProvider`] type with all stack
+    /// components.
+    pub async fn on_url(
+        self,
+        s: &str,
+    ) -> Result<PodProvider<impl Provider<BoxTransport, PodNetwork>, BoxTransport>, TransportError>
+    where
+        L: ProviderLayer<RootProvider<BoxTransport, PodNetwork>, BoxTransport, PodNetwork>,
+        F: TxFiller<PodNetwork> + ProviderLayer<L::Provider, BoxTransport, PodNetwork>,
+        F::Provider: 'static,
+    {
+        let alloy_provider = self.0.on_builtin(s).await?;
+        Ok(PodProvider::new(alloy_provider))
+    }
+
+    pub fn wallet<W>(self, wallet: W) -> PodProviderBuilder<L, JoinFill<F, WalletFiller<W>>> {
+        PodProviderBuilder::<_, _>(self.0.wallet(wallet))
+    }
+}
+
+/// A provider tailored for pod, extending capabilities of alloy [Provider]
+/// with pod-specific features.
+#[derive(Clone)]
+pub struct PodProvider<P, T>
+where
+    T: Transport + Clone,
+    P: Provider<T, PodNetwork>,
+{
+    inner: Arc<P>,
+    transport: std::marker::PhantomData<T>,
+}
+
+impl<P, T> Provider<T, PodNetwork> for PodProvider<P, T>
+where
+    T: Transport + Clone,
+    P: Provider<T, PodNetwork>,
+{
+    fn root(&self) -> &RootProvider<T, PodNetwork> {
+        self.inner.root()
     }
 }
 
@@ -58,20 +131,31 @@ pub enum LogVerificationError {
     InvalidReceiptResponse,
 }
 
-/// Extension trait that adds Pod-specific methods to any Provider with PodNetwork
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-pub trait PodProviderExt<T: Transport + Clone>: Provider<T, PodNetwork> {
+impl<P, T> PodProvider<P, T>
+where
+    T: Transport + Clone,
+    P: Provider<T, PodNetwork>,
+{
+    /// Create a new [PodProvider] using the underlying alloy [Provider].
+    pub fn new(provider: P) -> Self {
+        Self {
+            inner: Arc::new(provider),
+            transport: std::marker::PhantomData::<T>,
+        }
+    }
     /// Gets the current committee members
-    async fn get_committee(&self) -> TransportResult<Committee> {
+    pub async fn get_committee(&self) -> TransportResult<Committee> {
         self.client().request_noparams("pod_getCommittee").await
     }
 
-    async fn get_verifiable_logs(&self, filter: &Filter) -> TransportResult<Vec<VerifiableLog>> {
+    pub async fn get_verifiable_logs(
+        &self,
+        filter: &alloy_rpc_types::Filter,
+    ) -> TransportResult<Vec<VerifiableLog>> {
         self.client().request("eth_getLogs", (filter,)).await
     }
 
-    async fn websocket_subscribe<Params, Resp>(
+    pub async fn websocket_subscribe<Params, Resp>(
         &self,
         method: &str,
         params: Params,
@@ -79,8 +163,6 @@ pub trait PodProviderExt<T: Transport + Clone>: Provider<T, PodNetwork> {
     where
         Params: RpcParam,
         Resp: RpcReturn,
-        // Bounds from impl:
-        T: Transport + Clone,
     {
         let id = self
             .client()
@@ -89,14 +171,14 @@ pub trait PodProviderExt<T: Transport + Clone>: Provider<T, PodNetwork> {
         self.root().get_subscription(id).await
     }
 
-    async fn subscribe_verifiable_logs(
+    pub async fn subscribe_verifiable_logs(
         &self,
-        filter: &Filter,
+        filter: &alloy_rpc_types::Filter,
     ) -> TransportResult<Subscription<VerifiableLog>> {
         self.websocket_subscribe("logs", filter).await
     }
 
-    async fn wait_past_perfect_time(&self, timestamp: u64) -> TransportResult<()> {
+    pub async fn wait_past_perfect_time(&self, timestamp: u64) -> TransportResult<()> {
         loop {
             let subscription: Subscription<String> = self
                 .websocket_subscribe("pod_pastPerfectTime", timestamp)
@@ -110,14 +192,14 @@ pub trait PodProviderExt<T: Transport + Clone>: Provider<T, PodNetwork> {
         Ok(())
     }
 
-    async fn subscribe_confirmed_receipts(
+    pub async fn subscribe_confirmed_receipts(
         &self,
     ) -> TransportResult<Subscription<PodReceiptResponse>> {
         self.websocket_subscribe("pod_confirmedReceipts", None::<()>)
             .await
     }
 
-    async fn subscribe_account_receipts(
+    pub async fn subscribe_account_receipts(
         &self,
         account: &Address,
     ) -> TransportResult<Subscription<PodReceiptResponse>> {
@@ -125,7 +207,7 @@ pub trait PodProviderExt<T: Transport + Clone>: Provider<T, PodNetwork> {
             .await
     }
 
-    async fn get_confirmed_receipts(
+    pub async fn get_confirmed_receipts(
         &self,
         since_micros: u64,
         paginator: Option<CursorPaginationRequest>,
@@ -134,12 +216,21 @@ pub trait PodProviderExt<T: Transport + Clone>: Provider<T, PodNetwork> {
             .request("pod_listConfirmedReceipts", &(since_micros, paginator))
             .await
     }
-}
 
-// Implement for any Provider type that uses PodNetwork
-impl<T, P> PodProviderExt<T> for P
-where
-    T: Transport + Clone,
-    P: Provider<T, PodNetwork>,
-{
+    /// Transfer specified `amount` funds to the `to` account.
+    pub async fn transfer(
+        &self,
+        to: Address,
+        amount: U256,
+    ) -> Result<<PodNetwork as Network>::ReceiptResponse, Box<dyn std::error::Error>> {
+        let tx = PodTransactionRequest::default()
+            .with_to(to)
+            .with_value(amount);
+
+        let pending_tx = self.inner.send_transaction(tx).await?;
+
+        let receipt = pending_tx.get_receipt().await?;
+
+        Ok(receipt)
+    }
 }


### PR DESCRIPTION
Also added doctests with examples and re-exported useful alloy crates and types. A user doesn't need to import alloy crates manually anymore.