### PR TITLE
add SignerSync trait that allows signing TX in a non-async context

### DIFF
--- a/types/src/ledger/log.rs
+++ b/types/src/ledger/log.rs
@@ -83,7 +83,6 @@ impl VerifiableLog {
             signatures: self
                 .pod_metadata
                 .attestations
-                .clone()
                 .iter()
                 .map(|att| att.signature)
                 .collect(),


### PR DESCRIPTION
I think that the asynchronous `Signer` trait could be retired completely.