### PR TITLE
Correct setWinningChoice on voting example

### DIFF
--- a/examples/voting/contract/src/Voting.sol
+++ b/examples/voting/contract/src/Voting.sol
@@ -108,12 +108,9 @@ contract Voting {
     function setWinningChoice(bytes32 pollId, uint256 choice) public {
         Poll storage poll = polls[pollId];
         requireTimeAfter(poll.deadline, "Poll deadline has not passed yet");
-        require(poll.totalVotes > 0, "No votes have been cast");
         require(choice > 0 && choice <= poll.maxChoice, "Choice must be between 1 and maxChoice");
-        require(poll.winningChoice == 0, "Winner has already been set");
 
         uint256 voteCount = poll.voteCount[choice];
-        require(voteCount > 0, "This choice has received no votes");
 
         // Calculate remaining voters
         uint256 remainingVoters = poll.totalVoters - poll.totalVotes;
@@ -129,7 +126,7 @@ contract Voting {
         }
 
         // Verify this choice has enough votes that it cannot be overtaken
-        require(
+        requireQuorum(
             voteCount - secondHighestVotes > remainingVoters,
             "This choice could still be overtaken if remaining voters vote"
         );


### PR DESCRIPTION
In case multiple transactions try to set the winning choice at the same time: 1) they should all work if they were setting the correct choice 2) they should not work if they were not setting the correct choice 3) even on validators that the winning condition hasn't been met should pass the tx if the choice is winning according to the supermajority 4) unnecessary extra checks have been removed