### PR TITLE
Prepare Signed<T> to be persisted using types out of pod-types

### DIFF
--- a/types/src/consensus/attestation.rs
+++ b/types/src/consensus/attestation.rs
@@ -4,19 +4,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     Receipt, Signed, Timestamp, Transaction,
-    cryptography::{
-        hash::{Hash, Hashable},
-        signer::UncheckedSigned,
-    },
-    ledger::receipt::UncheckedReceipt,
+    cryptography::hash::{Hash, Hashable},
 };
 
 pub type TransactionAttestation = Attestation<Signed<Transaction>>;
 pub type ReceiptAttestation = Attestation<Receipt>;
-
-pub type UncheckedReceiptAttestation = Attestation<UncheckedReceipt>;
-
-pub type UncheckedTransactionAttestation = Attestation<UncheckedSigned<Transaction>>;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Indexed<T> {

--- a/types/src/ledger/receipt.rs
+++ b/types/src/ledger/receipt.rs
@@ -8,7 +8,7 @@ use super::{Transaction, log};
 use crate::cryptography::{
     hash::{Hash, Hashable},
     merkle_tree::{MerkleBuilder, MerkleMultiProof, MerkleProof, Merkleizable, index_prefix},
-    signer::{Signed, UncheckedSigned},
+    signer::Signed,
 };
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -112,44 +112,6 @@ impl From<Receipt> for TransactionReceipt {
             from: val.tx.signer,
             to: val.tx.signed.to.to().cloned(),
             contract_address: val.contract_address, // None if the transaction is not a contract creation.
-        }
-    }
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
-pub struct UncheckedReceipt {
-    pub status: bool,
-    pub actual_gas_used: u64,
-    pub logs: Vec<Log>,
-    pub logs_root: Hash,
-    pub tx: UncheckedSigned<Transaction>,
-    pub contract_address: Option<Address>,
-}
-
-impl From<Receipt> for UncheckedReceipt {
-    fn from(receipt: Receipt) -> Self {
-        Self {
-            status: receipt.status,
-            actual_gas_used: receipt.actual_gas_used,
-            logs: receipt.logs,
-            logs_root: receipt.logs_root,
-            tx: receipt.tx.into(),
-            contract_address: receipt.contract_address,
-        }
-    }
-}
-
-impl UncheckedReceipt {
-    /// Convert from an `UncheckedReceipt` to a fully fledged `Receipt`
-    /// _without_ re-verifying.
-    pub fn into_unchecked(self) -> Receipt {
-        Receipt {
-            status: self.status,
-            actual_gas_used: self.actual_gas_used,
-            logs: self.logs,
-            logs_root: self.logs_root,
-            tx: self.tx.into_signed_unchecked(),
-            contract_address: self.contract_address,
         }
     }
 }

--- a/types/src/ledger/transaction.rs
+++ b/types/src/ledger/transaction.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolValue;
 use crate::cryptography::{
     hash::{Hash, Hashable},
     merkle_tree::{MerkleBuilder, Merkleizable},
-    signer::{Signed, UncheckedSigned},
+    signer::Signed,
 };
 
 pub type Transaction = TxEip1559;
@@ -39,11 +39,5 @@ impl Hashable for Transaction {
 impl Hashable for Signed<Transaction> {
     fn hash_custom(&self) -> Hash {
         self.signed.tx_hash(&self.signature)
-    }
-}
-
-impl<T: Hashable + Clone> Hashable for UncheckedSigned<T> {
-    fn hash_custom(&self) -> Hash {
-        self.signed.hash_custom()
     }
 }


### PR DESCRIPTION
Part of POD-95

Allow creating Signed<T> from outside of the crate. The caller needs to maintain the signature invariant, which is emphasised with `unsafe` on `Signed::new_unchecked`.

Removed `Unchecked*` structures as they won't be needed anymore.