### PR TITLE
Implement or derive Arbitrary for some public types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,6 +3247,7 @@ dependencies = [
  "bytes",
  "hex",
  "itertools 0.13.0",
+ "pod-types",
  "rand 0.9.1",
  "serde",
  "serde_json",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,6 +14,14 @@ documentation = "https://docs.rs/pod-types"
 name = "pod_types"
 path = "src/lib.rs"
 
+[features]
+default = []
+arbitrary = [
+  "alloy-consensus/arbitrary",
+  "alloy-primitives/arbitrary",
+  "dep:arbitrary",
+]
+
 [dependencies]
 alloy-consensus = { version = "0.12.1", features = [
   "serde",
@@ -37,10 +45,11 @@ serde_with = "3.12.0"
 thiserror = "2.0.12"
 tracing = "0.1.41"
 
+arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 arbitrary = "1.4.1"
-alloy-consensus = { version = "0.12.1", features = ["arbitrary"] }
+pod-types = { path = ".", features = ["arbitrary"] }
 bincode = { version = "2.0.1", features = ["serde"] }
 rand = "0.9.1"
 serde_json = "*"

--- a/types/src/consensus/certificate.rs
+++ b/types/src/consensus/certificate.rs
@@ -2,7 +2,8 @@ use alloy_primitives::PrimitiveSignature;
 use serde::{Deserialize, Serialize};
 
 // Certificate represents a proof on an agreement by the committee
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Certificate<T> {
     pub signatures: Vec<PrimitiveSignature>,
     pub certified: T,

--- a/types/src/ledger/log.rs
+++ b/types/src/ledger/log.rs
@@ -36,6 +36,7 @@ pub fn to_rpc_format(inner_log: Log, tx_hash: Hash) -> RPCLog {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Event {
     pub log: Log,
     pub log_index: u64,

--- a/types/src/ledger/receipt.rs
+++ b/types/src/ledger/receipt.rs
@@ -12,6 +12,7 @@ use crate::cryptography::{
 };
 
 #[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Receipt {
     pub status: bool,
     pub actual_gas_used: u64,

--- a/types/src/time.rs
+++ b/types/src/time.rs
@@ -25,6 +25,7 @@ pub enum TimestampError {
     std::hash::Hash,
     Default,
 )]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Timestamp(u128);
 
 impl Timestamp {


### PR DESCRIPTION
This pull request introduces support for the `arbitrary` crate to enable property-based testing across various data structures and types. It includes updates to dependencies, feature flags, and the implementation of `Arbitrary` trait for several types. Below is a summary of the most significant changes grouped by theme.

### Dependency and Configuration Updates:
* Added a new optional `arbitrary` feature in `Cargo.toml` to enable property-based testing. Updated dependencies for `arbitrary` and related features in `alloy-consensus` and `alloy-primitives`. [[1]](diffhunk://#diff-2a79be523c65dbf95985584181916ee493f6ffefc49d09e6ecadd05db4302d9fR17-L23) [[2]](diffhunk://#diff-2a79be523c65dbf95985584181916ee493f6ffefc49d09e6ecadd05db4302d9fR50-R56)

### Implementation of `Arbitrary` Trait:
* Implemented the `arbitrary::Arbitrary` trait for `Attestation<T>` to generate random attestations, including signing the data with a random private key.
* Added `arbitrary::Arbitrary` implementations for `Signed<T>` to support random generation of signed objects, including signatures.

### Data Structure Enhancements:
* Updated several structs (`Indexed<T>`, `Certificate<T>`, `Receipt`, and `Timestamp`) to derive `arbitrary::Arbitrary` when the `arbitrary` feature is enabled. This allows these types to be used in property-based testing. [[1]](diffhunk://#diff-9574545b2797cee89897f103d5e14c1d45ec6d27b7b2e85bece3610bbf664c33R14) [[2]](diffhunk://#diff-2102ca3f093318cf606e27e3f9b0a2f43a4345c446a24d8f0e232bf2d43d2c82L7-R8) [[3]](diffhunk://#diff-eecf536afe27e228eb833b4b7d6c8704bd38f18bff32c949c2b87db51da6473bR16) [[4]](diffhunk://#diff-e1139e5dfab2fecf14f7c3748b02c0fd0764ec32e5c62cf613e16ecfa72dfed5R28)

These changes enhance the testability of the codebase by enabling property-based testing, which can help uncover edge cases and improve overall reliability.