### PR TITLE
cache Signed<T> hash

### DIFF
--- a/types/src/ledger/transaction.rs
+++ b/types/src/ledger/transaction.rs
@@ -1,11 +1,10 @@
-use alloy_consensus::{SignableTransaction, TxEip1559, transaction::RlpEcdsaEncodableTx};
+use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_primitives::Address;
 use alloy_sol_types::SolValue;
 
 use crate::cryptography::{
     hash::{Hash, Hashable},
     merkle_tree::{MerkleBuilder, Merkleizable},
-    signer::Signed,
 };
 
 pub type Transaction = TxEip1559;
@@ -32,12 +31,5 @@ impl Merkleizable for Transaction {
 impl Hashable for Transaction {
     fn hash_custom(&self) -> Hash {
         self.signature_hash()
-    }
-}
-
-// the actual hash used for identifying a transaction
-impl Hashable for Signed<Transaction> {
-    fn hash_custom(&self) -> Hash {
-        self.signed.tx_hash(&self.signature)
     }
 }


### PR DESCRIPTION
`Signed` hash calculation is compute-intensive and shows up in flamegraphs of the stress tests, where it is responsible for around 5%-10% of time. This PR adds seamless caching of the signed transaction hash to avoid recomputing it multiple times.

The performance in the `end_to_end_throughput` stress test changes from around 900 TPS to 980 TPS by applying this change  (averaged over 3 runs).

<img width="3788" height="1796" alt="image" src="https://github.com/user-attachments/assets/fc4ddebb-9445-4022-93c8-1f34239f2402" />
