### PR TITLE
CI: detect unused dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,20 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Cache cargo dependencies
-      id: cache-cargo
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-cargo-dependencies
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-
+    - uses: Swatinem/rust-cache@v2
     - name: Versions
       run: |
         cargo version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,16 @@ jobs:
 
     - name: Run clippy
       run: cargo clippy -- -D warnings
+
+  check-for-unused-deps:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install cargo-binstall
+      uses: cargo-bins/cargo-binstall@main
+
+    - name: Install cargo-shear
+      run: cargo binstall --no-confirm cargo-shear
+
+    - run: cargo shear

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Cache cargo dependencies
-      id: cache-cargo
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-cargo-dependencies
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+    - uses: Swatinem/rust-cache@v2
 
     - name: Version
       run: cargo version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4832,7 +4832,6 @@ dependencies = [
  "clap",
  "futures",
  "hex",
- "humantime",
  "pod-sdk",
  "pod-types",
  "tokio",

--- a/examples/voting/client/Cargo.toml
+++ b/examples/voting/client/Cargo.toml
@@ -13,5 +13,4 @@ tokio = { version = "1.45.1", features = ["full"] }
 anyhow = "1.0.98"
 clap = { version = "4.5.38", features = ["derive"] }
 hex = "0.4.3"
-humantime = "2.2.0"
 futures = "0.3.31"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -22,6 +22,11 @@ arbitrary = [
   "dep:arbitrary",
 ]
 
+[package.metadata.cargo-shear]
+ignored = [
+  "pod-types", # self-depend for tests to enable the arbitrary feature
+]
+
 [dependencies]
 alloy-consensus = { version = "0.12.1", features = [
   "serde",


### PR DESCRIPTION
Check for unused deps in CI to prevent leaving redundant deps in Cargo.toml files.

Also replaced caching method in CI with https://github.com/Swatinem/rust-cache which, in my experience, is more effective and doesn't require configuration.