### PR TITLE
Add fixed rust version for lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: 1.88
+        components: clippy
+
     - uses: Swatinem/rust-cache@v2
     - name: Versions
       run: |


### PR DESCRIPTION
GitHub updated their Actions instances to latest rust, which broke our clippy. This makes the rust version fixed.