### PR TITLE
Prepare to publish pod-examples-solidity crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ dependencies = [
  "clap",
  "futures",
  "hex",
- "pod-examples-solidity 0.1.0",
+ "pod-examples-solidity",
  "pod-sdk",
  "pod-types",
  "tokio",
@@ -3260,7 +3260,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dotenv",
- "pod-examples-solidity 0.1.0",
+ "pod-examples-solidity",
  "pod-optimistic-auction",
  "pod-sdk",
  "pod-types",
@@ -3465,16 +3465,7 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "pod-examples-solidity"
-version = "0.1.0"
-dependencies = [
- "alloy",
- "serde",
-]
-
-[[package]]
-name = "pod-examples-solidity"
-version = "0.1.0"
-source = "git+https://github.com/podnetwork/pod-sdk?rev=cab43b2075fb683f3eb5c34cf7b738f420b0c31d#cab43b2075fb683f3eb5c34cf7b738f420b0c31d"
+version = "0.2.0"
 dependencies = [
  "alloy",
  "serde",
@@ -3508,7 +3499,7 @@ dependencies = [
  "async-trait",
  "futures",
  "hex",
- "pod-examples-solidity 0.1.0 (git+https://github.com/podnetwork/pod-sdk?rev=cab43b2075fb683f3eb5c34cf7b738f420b0c31d)",
+ "pod-examples-solidity",
  "pod-types",
  "serde",
  "tokio-test",
@@ -3933,7 +3924,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
- "pod-examples-solidity 0.1.0",
+ "pod-examples-solidity",
  "pod-sdk",
  "pod-types",
  "tokio",

--- a/examples/solidity/Makefile
+++ b/examples/solidity/Makefile
@@ -1,7 +1,7 @@
 generate:
-	forge bind --crate-name pod-examples-solidity --bindings-path ./bindings --alloy-version 1.0.24 --force --no-metadata --overwrite --skip script
+	forge bind --crate-name pod-examples-solidity --crate-version 0.2.0 --bindings-path ./bindings --alloy-version 1.0.24 --force --no-metadata --overwrite --skip script
 
 check:
-	forge bind --crate-name pod-examples-solidity --bindings-path ./bindings --alloy-version 1.0.24 --force --no-metadata --skip script
+	forge bind --crate-name pod-examples-solidity --crate-version 0.2.0 --bindings-path ./bindings --alloy-version 1.0.24 --force --no-metadata --skip script
 .PHONY: generate
 .PHONY: check

--- a/examples/solidity/bindings/Cargo.toml
+++ b/examples/solidity/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pod-examples-solidity"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -16,8 +16,7 @@ path = "src/lib.rs"
 
 [dependencies]
 pod-types = { path = "../types", version = "0.2.0" }
-# TODO: use `path` and `version` when we publish the bindings crate.
-pod-contracts = { package = "pod-examples-solidity", git = "https://github.com/podnetwork/pod-sdk", rev = "cab43b2075fb683f3eb5c34cf7b738f420b0c31d" }
+pod-contracts = { path = "../examples/solidity/bindings", package = "pod-examples-solidity", version = "0.2.0" }
 
 alloy-primitives = { version = "1.3.0", features = ["k256", "serde"] }
 alloy-sol-types = "1.3.0"


### PR DESCRIPTION
Tag pod-examples-solidity crate with version 0.2.0 and depend on its published version in pod-sdk for auction bindings.