### PR TITLE
fix(solidity): add missing SPDX license identifier to FastTypes.sol

### DIFF
--- a/solidity-sdk/src/FastTypes.sol
+++ b/solidity-sdk/src/FastTypes.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
 import {requireQuorum} from "./Quorum.sol";


### PR DESCRIPTION
## Summary

`FastTypes.sol` was the only Solidity file in the SDK missing an `// SPDX-License-Identifier:` header. All other files (`Context.sol`, `Quorum.sol`, `Time.sol`) use `MIT`. The missing identifier produces a compiler warning on every build:

```
Warning: SPDX license identifier not provided in source file.
```

Added `// SPDX-License-Identifier: MIT` to match the rest of the codebase.

## Test plan

- [ ] Confirm `forge build` produces no SPDX-related warnings after this change