### PR TITLE
perf:  This PR removes avoidable allocations in the Merkle proof path.

### DIFF
--- a/types/src/cryptography/merkle_tree.rs
+++ b/types/src/cryptography/merkle_tree.rs
@@ -416,22 +416,25 @@ impl MerkleTree {
 
         let mut stack = leaves.to_vec();
 
-        let mut path = proof.path.to_vec();
+        let path = proof.path;
+        let mut cursor = 0;
 
         for flag in proof.flags {
             let a = stack.remove(0);
             let b = if flag {
                 stack.remove(0)
             } else {
-                path.remove(0)
+                let value = path[cursor];
+                cursor += 1;
+                value
             };
 
             stack.push(commutative_hash_pair(a, b));
         }
 
-        let reconstructed_root = match (stack.len(), path.len()) {
+        let reconstructed_root = match (stack.len(), path.len() - cursor) {
             (1, 0) => stack.remove(0),
-            (0, 1) => path.remove(0),
+            (0, 1) => path[cursor],
             _ => {
                 tracing::debug!("invalid multiproof: invalid total hashes");
                 return false;

--- a/types/src/cryptography/merkle_tree.rs
+++ b/types/src/cryptography/merkle_tree.rs
@@ -5,7 +5,7 @@ use std::{
     ops::Deref,
 };
 
-use crate::cryptography::hash::{Hash, Hashable};
+use crate::cryptography::hash::{Hash, Hashable, hash};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum MerkleError {
@@ -50,7 +50,10 @@ impl MerkleProof {
 }
 
 fn hash_pair(left: Hash, right: Hash) -> Hash {
-    [left, right].concat().hash_custom()
+    let mut bytes = [0u8; 64];
+    bytes[..32].copy_from_slice(left.as_slice());
+    bytes[32..].copy_from_slice(right.as_slice());
+    hash(bytes)
 }
 
 fn commutative_hash_pair(left: Hash, right: Hash) -> Hash {


### PR DESCRIPTION
- avoid cloning `proof.path` in `verify_multi_proof` by consuming the owned vector directly
- avoid allocating a temporary `Vec` in `hash_pair` by hashing a stack-allocated `[u8; 64]`

You can also do the same to: 
` let mut stack = leaves.to_vec()`, it's very possible to skip this allocation using a new `Vec and with_capacity`.

should be able to do more but that would clutter the pr