### PR TITLE
Add bridge setup deployment script

### DIFF
--- a/protocol/deploy/03_BridgeSetup.sol
+++ b/protocol/deploy/03_BridgeSetup.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {console, Script} from "forge-std/Script.sol";
+import {Bridge} from "pod-protocol/Bridge.sol";
+import {DepositWaitingList} from "pod-protocol/DepositWaitingList.sol";
+
+contract BridgeSetup is Script {
+    function run(
+        Bridge bridge,
+        DepositWaitingList waitlist,
+        address[] memory tokens,
+        address[] memory addValidators
+    ) public {
+        address admin = msg.sender;
+
+        address[] memory removeValidators = new address[](1);
+        removeValidators[0] = admin;
+
+        vm.startBroadcast();
+
+        // Grant RELAYER_ROLE on the bridge to the waitlist contract
+        bridge.grantRole(bridge.RELAYER_ROLE(), address(waitlist));
+
+        // Approve tokens on the waitlist for bridge transfers
+        for (uint256 i = 0; i < tokens.length; i++) {
+            waitlist.approveToken(tokens[i]);
+        }
+
+        // Update validator config: keep existing version and resilience, add real validators, remove admin
+        bridge.updateValidatorConfig(
+            bridge.adversarialResilience(),
+            bridge.version(),
+            bytes32(0),
+            addValidators,
+            removeValidators
+        );
+
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `deploy/03_BridgeSetup.sol` script that configures the bridge and waitlist post-deployment:
  - Grants `RELAYER_ROLE` on the bridge to the waitlist contract
  - Approves tokens on the waitlist for bridge transfers
  - Updates validator config: keeps existing resilience and version, adds real validators, removes admin

## Usage

```bash
forge script deploy/03_BridgeSetup.sol:BridgeSetup \
  --sig "run(address,address,address[],address[])" \
  <BRIDGE_PROXY> <WAITLIST> "[<TOKEN1>,<TOKEN2>]" "[<VALIDATOR1>,<VALIDATOR2>]" \
  --rpc-url $RPC_URL \
  --private-key $PRIVATE_KEY \
  --broadcast
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)