### PR TITLE
docs: add recovery precompile page and update orderbook interface

### DIFF
--- a/doc/api-reference/SUMMARY.md
+++ b/doc/api-reference/SUMMARY.md
@@ -29,6 +29,7 @@
   * [Orderbook Spot](applications-precompiles/orderbook-spot.md)
   * [Optimistic Auctions](applications-precompiles/wip-optimistic-auctions.md)
   * [Bridge](applications-precompiles/bridge.md)
+  * [Recovery](applications-precompiles/recovery.md)
 
 ## Case Studies
 

--- a/doc/api-reference/applications-precompiles/README.md
+++ b/doc/api-reference/applications-precompiles/README.md
@@ -102,20 +102,21 @@ const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 const ORDERBOOK = "0x50d0000000000000000000000000000000000002";
 const abi = [
   `function submitOrder(
-    bytes32 orderbookId, int256 volume, uint256 price,
-    uint128 deadline, uint128 ttl, bool reduceOnly
+    bytes32 orderbookId, int256 size, uint256 price,
+    uint8 orderType, uint128 deadline, uint128 ttl, bool reduceOnly
   )`
 ];
 const orderbook = new ethers.Contract(ORDERBOOK, abi, signer);
 
 const orderbookId = "0x0000000000000000000000000000000000000000000000000000000000000001";
-const volume = ethers.parseEther("1");          // buy 1 unit
+const size = ethers.parseEther("1");            // buy 1 unit
 const price = ethers.parseEther("5000");        // limit price
+const orderType = 0;                            // 0 = Limit, 1 = Market
 const deadline = BigInt(Date.now()) * 1000n;    // now in microseconds
 const ttl = 60n * 1_000_000n;                  // 60 seconds in microseconds
 
 const tx = await orderbook.submitOrder(
-  orderbookId, volume, price, deadline, ttl, false
+  orderbookId, size, price, orderType, deadline, ttl, false
 );
 console.log("Order tx:", tx.hash);
 ```
@@ -132,8 +133,9 @@ account = w3.eth.account.from_key(os.environ["PRIVATE_KEY"])
 ORDERBOOK = "0x50d0000000000000000000000000000000000002"
 abi = [{"inputs": [
     {"name": "orderbookId", "type": "bytes32"},
-    {"name": "volume", "type": "int256"},
+    {"name": "size", "type": "int256"},
     {"name": "price", "type": "uint256"},
+    {"name": "orderType", "type": "uint8"},
     {"name": "deadline", "type": "uint128"},
     {"name": "ttl", "type": "uint128"},
     {"name": "reduceOnly", "type": "bool"}],
@@ -144,8 +146,9 @@ orderbook = w3.eth.contract(address=ORDERBOOK, abi=abi)
 
 tx = orderbook.functions.submitOrder(
     bytes.fromhex("00" * 31 + "01"),            # orderbook id
-    10**18,                                      # volume: buy 1 unit
+    10**18,                                      # size: buy 1 unit
     5000 * 10**18,                               # limit price
+    0,                                           # order type: 0 = Limit
     int(time.time() * 1_000_000),                # deadline in microseconds
     60 * 1_000_000,                              # ttl: 60 seconds
     False,                                       # reduce only
@@ -173,9 +176,10 @@ use alloy::{
 sol! {
     #[sol(rpc)]
     contract Orderbook {
+        enum OrderType { Limit, Market }
         function submitOrder(
-            bytes32 orderbookId, int256 volume, uint256 price,
-            uint128 deadline, uint128 ttl, bool reduceOnly
+            bytes32 orderbookId, int256 size, uint256 price,
+            OrderType orderType, uint128 deadline, uint128 ttl, bool reduceOnly
         ) public;
     }
 }
@@ -202,6 +206,7 @@ async fn main() -> eyre::Result<()> {
         FixedBytes::left_padding_from(&[1]),     // orderbook id
         I256::from_raw(U256::from(10).pow(U256::from(18))), // buy 1 unit
         U256::from(5000) * U256::from(10).pow(U256::from(18)), // limit price
+        Orderbook::OrderType::Limit,             // order type
         now_us,                                   // deadline
         60 * 1_000_000,                          // ttl: 60 seconds
         false,                                    // reduce only

--- a/doc/api-reference/applications-precompiles/README.md
+++ b/doc/api-reference/applications-precompiles/README.md
@@ -10,9 +10,6 @@ Pod uses precompiles for enshrined applications and internal protocol operations
 | [Bridge](bridge.md) | `0x50d0000000000000000000000000000000000001` | ERC-20 token bridging between Pod and Ethereum |
 | [Optimistic Auctions](wip-optimistic-auctions.md) | `0xeDD0670497E00ded712a398563Ea938A29dD28c7` | Censorship-resistant auction for intents (settlement happens off-Pod) |
 | [Recovery](recovery.md) | `0x50d0000000000000000000000000000000000003` | Recover a locked account by finalizing the target transaction chain |
-| `requireQuorum(boolean)` | `0x4CF3F1637bfEf1534e56352B6ebAae243aF464c3` | Like `require` but passes if supermajority agrees |
-| `external_call([uint256, [Transaction,bytes]])` | `0x8712E00C337971f876621faB9326908fdF330d77` | Call a smart contract on another EVM-compatible chain |
-| `call_with_state([uint256, Header, EVMCall, EVMState])` | `0xb4bbff8874b41f97535bc8dafbaaff0dc5c72e5a` | Simulate an EVM transaction execution given a particular initial state |
 
 ## Interacting with Precompiles
 

--- a/doc/api-reference/applications-precompiles/README.md
+++ b/doc/api-reference/applications-precompiles/README.md
@@ -9,7 +9,7 @@ Pod uses precompiles for enshrined applications and internal protocol operations
 | [Orderbook Spot](orderbook-spot.md) | `0x50d0000000000000000000000000000000000002` | Central limit order book for spot markets |
 | [Bridge](bridge.md) | `0x50d0000000000000000000000000000000000001` | ERC-20 token bridging between Pod and Ethereum |
 | [Optimistic Auctions](wip-optimistic-auctions.md) | `0xeDD0670497E00ded712a398563Ea938A29dD28c7` | Censorship-resistant auction for intents (settlement happens off-Pod) |
-| `recover(bytes32 txHash, uint64 nonce)` | `0x0000000000000000000000000000000004EC0EE4` | Recover a locked account by finalizing the target transaction chain |
+| [Recovery](recovery.md) | `0x50d0000000000000000000000000000000000003` | Recover a locked account by finalizing the target transaction chain |
 | `requireQuorum(boolean)` | `0x4CF3F1637bfEf1534e56352B6ebAae243aF464c3` | Like `require` but passes if supermajority agrees |
 | `external_call([uint256, [Transaction,bytes]])` | `0x8712E00C337971f876621faB9326908fdF330d77` | Call a smart contract on another EVM-compatible chain |
 | `call_with_state([uint256, Header, EVMCall, EVMState])` | `0xb4bbff8874b41f97535bc8dafbaaff0dc5c72e5a` | Simulate an EVM transaction execution given a particular initial state |

--- a/doc/api-reference/applications-precompiles/orderbook-spot.md
+++ b/doc/api-reference/applications-precompiles/orderbook-spot.md
@@ -22,22 +22,43 @@ Use it for **placing/canceling orders**, **depositing/withdrawing funds**, and *
  */
 contract Orderbook {
 
+    enum Side { Buy, Sell }
+    enum OrderType { Limit, Market }
+
+    struct SolutionCallData {
+        bytes32[] orders;
+        bytes32[] cancels;
+        bytes32[] updates;
+    }
+
+    // --- Events ---
+
+    event SolutionExecuted(
+        bytes32 indexed orderbookId,
+        uint128 deadline,
+        uint256 clearingPrice,
+        uint256 totalVolume,
+        uint256 newOrdersCount
+    );
+
     // --- Order Management ---
 
     /**
      * Submits a new order to the orderbook.
-     * The direction of the trade (Bid/Ask) is determined by the sign of the volume.
+     * The direction of the trade (Bid/Ask) is determined by the sign of the size.
      * @param orderbookId The unique identifier of the specific market (e.g., ETH-USDC).
-     * @param volume The size of the order. Positive (+) for Buy/Bid, Negative (-) for Sell/Ask.
+     * @param size The size of the order. Positive (+) for Buy/Bid, Negative (-) for Sell/Ask.
      * @param price The limit price for the order.
+     * @param orderType The order type (Limit or Market).
      * @param deadline The timestamp limit for this order to be included in a batch in microseconds.
      * @param ttl The "Time To Live" duration in microseconds; how long the order remains active in the book.
      * @param reduceOnly If true, this order will only reduce an existing position and not increase leverage.
      */
     function submitOrder(
         bytes32 orderbookId,
-        int256 volume,
+        int256 size,
         uint256 price,
+        OrderType orderType,
         uint128 deadline,
         uint128 ttl,
         bool reduceOnly
@@ -55,12 +76,41 @@ contract Orderbook {
         uint128 deadline
     ) public {}
 
+    /**
+     * @notice Updates an existing open order.
+     * @param orderbookId The unique identifier of the market the order belongs to.
+     * @param updatedOrder The unique hash/identifier of the order to update.
+     * @param newSize The new size for the order.
+     * @param newPrice The new price for the order.
+     * @param token The token address for any additional cost.
+     * @param extraCost The additional cost for the update.
+     * @param deadline The Unix timestamp after which this update is invalid in microseconds.
+     */
+    function update(
+        bytes32 orderbookId,
+        bytes32 updatedOrder,
+        uint256 newSize,
+        uint256 newPrice,
+        address token,
+        uint256 extraCost,
+        uint128 deadline
+    ) public {}
+
     // --- Data Retrieval ---
 
     /**
-     * @notice Retrieves the deposited balance of a user for a specific token.
+     * @notice Retrieves the deposited balance of a token for a specific account.
+     * @param token The address of the ERC20 token to check.
+     * @param account The address of the account to check.
+     * @return The current balance of the token held by the account within the exchange.
+     */
+    function balanceOf(address token, address account) public view returns (uint256) {}
+
+    /**
+     * @notice Retrieves the deposited balance of the caller for a specific token.
      * @param token The address of the ERC20 token to check.
      * @return The current balance of the token held by the caller within the exchange.
+     * @deprecated Use balanceOf(address token, address account) instead.
      */
     function getBalance(address token) public view returns (uint256) {}
 
@@ -115,5 +165,22 @@ contract Orderbook {
         uint256 amount,
         uint128 deadline
     ) public {}
+
+    // --- Orderbook Management ---
+
+    /**
+     * @notice Creates a new orderbook for a trading pair.
+     * @param base The address of the base token.
+     * @param quote The address of the quote token.
+     * @param auctionInterval The interval between batch auctions in microseconds.
+     * @param solverPk The public key of the solver for this orderbook.
+     * @return The unique identifier for the new orderbook.
+     */
+    function createOrderBook(
+        address base,
+        address quote,
+        uint128 auctionInterval,
+        bytes solverPk
+    ) public returns (bytes32) {}
 }
 ```

--- a/doc/api-reference/applications-precompiles/recovery.md
+++ b/doc/api-reference/applications-precompiles/recovery.md
@@ -1,0 +1,25 @@
+# Recovery
+
+The recovery precompile allows users to recover a locked account by finalizing the target transaction chain. Accounts can become locked when conflicting transactions are submitted at the same nonce.
+
+For background on why accounts get locked and how the recovery protocol works, see [Local Ordering](https://docs.v2.pod.network/documentation/network-architecture/local-ordering#account-locking-and-recovery). For a step-by-step guide, see [Recover a locked account](../guides/recover-locked-account.md).
+
+**Precompile address:** `0x50d0000000000000000000000000000000000003`
+
+## Interface
+
+```solidity
+interface IRecovery {
+    /// @notice Recover a locked account by finalizing the target transaction chain.
+    /// @param txHash The hash of the target transaction to recover to (obtained via pod_getRecoveryTargetTx).
+    /// @param nonce The nonce of the target transaction (obtained via pod_getRecoveryTargetTx).
+    function recover(bytes32 txHash, uint64 nonce) external;
+}
+```
+
+## Usage
+
+1. Call `pod_getRecoveryTargetTx(account)` on the full node to get the target transaction hash and nonce.
+2. Send a transaction to the recovery precompile calling `recover(txHash, nonce)` with the values from step 1.
+
+The protocol will finalize the target transaction chain, recover your account state, and increment the nonce. You can then send a new transaction with the next nonce.

--- a/doc/api-reference/guides/place-an-order.md
+++ b/doc/api-reference/guides/place-an-order.md
@@ -5,7 +5,7 @@ This guide walks through placing a limit order on Pod's orderbook. For backgroun
 ## Steps
 
 1. Deposit tokens into the orderbook contract.
-2. Submit a limit order with price, volume, deadline, and TTL.
+2. Submit a limit order with price, size, deadline, and TTL.
 
 {% tabs %}
 {% tab title="TypeScript (ethers.js)" %}
@@ -18,7 +18,7 @@ const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
 const ORDERBOOK = "0x50d0000000000000000000000000000000000002";
 const abi = [
   "function deposit(address token, address recipient, uint256 amount, uint128 deadline)",
-  "function submitOrder(bytes32 orderbookId, int256 volume, uint256 price, uint128 deadline, uint128 ttl, bool reduceOnly)",
+  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, bool reduceOnly)",
 ];
 const orderbook = new ethers.Contract(ORDERBOOK, abi, wallet);
 
@@ -31,12 +31,13 @@ const depositAmount = ethers.parseEther("1000");
 await (await orderbook.deposit(USDT, wallet.address, depositAmount, now + 60_000_000n)).wait();
 
 // 2. Submit a buy limit order
-const volume = ethers.parseEther("1");       // buy 1 unit (positive = buy)
+const size = ethers.parseEther("1");         // buy 1 unit (positive = buy)
 const price = ethers.parseEther("5000");     // limit price
+const orderType = 0;                         // 0 = Limit, 1 = Market
 const deadline = now + 10_000_000n;          // include in batches within next 10 seconds
 const ttl = 60n * 1_000_000n;               // order lives for 60 seconds
 
-const tx = await orderbook.submitOrder(orderbookId, volume, price, deadline, ttl, false);
+const tx = await orderbook.submitOrder(orderbookId, size, price, orderType, deadline, ttl, false);
 console.log("Order tx:", tx.hash);
 ```
 {% endtab %}
@@ -52,9 +53,10 @@ sol! {
     #[sol(rpc)]
     contract Orderbook {
         function deposit(address token, address recipient, uint256 amount, uint128 deadline) public;
+        enum OrderType { Limit, Market }
         function submitOrder(
-            bytes32 orderbookId, int256 volume, uint256 price,
-            uint128 deadline, uint128 ttl, bool reduceOnly
+            bytes32 orderbookId, int256 size, uint256 price,
+            OrderType orderType, uint128 deadline, uint128 ttl, bool reduceOnly
         ) public;
     }
 }
@@ -82,13 +84,13 @@ orderbook
     .send().await?.watch().await?;
 
 // 2. Submit a buy limit order
-let volume = I256::from_raw(U256::from(10).pow(U256::from(18))); // buy 1 unit
+let size = I256::from_raw(U256::from(10).pow(U256::from(18))); // buy 1 unit
 let price = U256::from(5000) * U256::from(10).pow(U256::from(18)); // limit price
 let deadline = now_us + 10_000_000; // include in batches within next 10 seconds
 let ttl = 60 * 1_000_000; // order lives for 60 seconds
 
 let tx = orderbook
-    .submitOrder(orderbook_id, volume, price, deadline, ttl, false)
+    .submitOrder(orderbook_id, size, price, Orderbook::OrderType::Limit, deadline, ttl, false)
     .send().await?;
 println!("Order tx: {:?}", tx.tx_hash());
 ```

--- a/doc/api-reference/guides/recover-locked-account.md
+++ b/doc/api-reference/guides/recover-locked-account.md
@@ -5,7 +5,7 @@ If your account is locked due to conflicting transactions at the same nonce, you
 ## Steps
 
 1. Call `pod_getRecoveryTargetTx(account)` on the full node to get the target transaction to recover to.
-2. Send a transaction to the recovery precompile at `0x0000000000000000000000000000000004EC0EE4`, calling `recover(txHash, nonce)` with the values from step 1.
+2. Send a transaction to the recovery precompile at `0x50d0000000000000000000000000000000000003`, calling `recover(txHash, nonce)` with the values from step 1.
 
 The protocol will finalize the target transaction chain, recover your account state, and increment the nonce. You can then send a new transaction with the next nonce.
 
@@ -17,7 +17,7 @@ import { ethers } from "ethers";
 const provider = new ethers.JsonRpcProvider("https://rpc.v1.dev.pod.network");
 const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
 
-const RECOVERY = "0x0000000000000000000000000000000004EC0EE4";
+const RECOVERY = "0x50d0000000000000000000000000000000000003";
 const abi = ["function recover(bytes32 txHash, uint64 nonce) public"];
 const recovery = new ethers.Contract(RECOVERY, abi, wallet);
 
@@ -49,7 +49,7 @@ let provider = ProviderBuilder::new()
     .on_http("https://rpc.v1.dev.pod.network".parse()?);
 
 let recovery = Recovery::new(
-    "0x0000000000000000000000000000000004EC0EE4".parse()?,
+    "0x50d0000000000000000000000000000000000003".parse()?,
     &provider,
 );
 


### PR DESCRIPTION
## Summary
- Add dedicated Recovery precompile reference page under References/Precompiles
- Update recovery precompile address to `0x50d0...0003` across all docs
- Remove requireQuorum, external_call, call_with_state from precompiles table
- Sync orderbook spot interface with `podnetwork/pod` (added `OrderType` enum, `update()`, `balanceOf()`, `createOrderBook()`, `SolutionExecuted` event)
- Update `submitOrder` examples in precompiles page and place-an-order guide (rename `volume` to `size`, add `OrderType` param)