### PR TITLE
fix: pass fault tolerance to bridge deploy script

### DIFF
--- a/protocol/script/DeployBridge.s.sol
+++ b/protocol/script/DeployBridge.s.sol
@@ -29,13 +29,10 @@ library BridgeDeployer {
 }
 
 contract Deploy is BaseDeployer {
-    function run(
-        address podBridgeAddr,
-        uint256 srcChainId,
-        uint256 version,
-        bytes32 merkleRoot,
-        uint64 faultTolerance
-    ) external returns (address proxy) {
+    function run(address podBridgeAddr, uint256 srcChainId, uint256 version, bytes32 merkleRoot, uint64 faultTolerance)
+        external
+        returns (address proxy)
+    {
         address[] memory initialValidators = getValidatorAddresses();
         vm.startBroadcast();
 

--- a/protocol/script/DeployBridge.s.sol
+++ b/protocol/script/DeployBridge.s.sol
@@ -29,17 +29,19 @@ library BridgeDeployer {
 }
 
 contract Deploy is BaseDeployer {
-    function run(address podBridgeAddr, uint256 srcChainId, uint256 version, bytes32 merkleRoot)
-        external
-        returns (address proxy)
-    {
+    function run(
+        address podBridgeAddr,
+        uint256 srcChainId,
+        uint256 version,
+        bytes32 merkleRoot,
+        uint64 faultTolerance
+    ) external returns (address proxy) {
         address[] memory initialValidators = getValidatorAddresses();
         vm.startBroadcast();
 
-        uint8 f = uint8((initialValidators.length - 1) / 5);
-
-        (Bridge bridgeProxy, Bridge implementation) =
-            BridgeDeployer.deploy(podBridgeAddr, srcChainId, msg.sender, initialValidators, f, version, merkleRoot);
+        (Bridge bridgeProxy, Bridge implementation) = BridgeDeployer.deploy(
+            podBridgeAddr, srcChainId, msg.sender, initialValidators, faultTolerance, version, merkleRoot
+        );
 
         vm.stopBroadcast();
 

--- a/protocol/script/deploy_bridge.bash
+++ b/protocol/script/deploy_bridge.bash
@@ -16,6 +16,7 @@ source .env
 : "${POD_CHAIN_ID:=1293}"   # Pod network chain ID (0x50d)
 : "${BRIDGE_VERSION:=1}"
 : "${BRIDGE_MERKLE_ROOT:=0x0000000000000000000000000000000000000000000000000000000000000000}"
+: "${FAULT_TOLERANCE:=0}"
 
 echo "SOURCE_CHAIN_RPC: $SOURCE_CHAIN_RPC"
 echo "PK_SOURCE_CHAIN: $PK_SOURCE_CHAIN"
@@ -26,8 +27,8 @@ echo "POD_COMMITTEE_KEYS: $POD_COMMITTEE_KEYS"
 OUTPUT=$(forge script ./script/DeployBridge.s.sol:Deploy \
   --rpc-url "$SOURCE_CHAIN_RPC" --private-key "$PK_SOURCE_CHAIN" --broadcast --slow \
   --json \
-  --sig "run(address,uint256,uint256,bytes32)" \
-  "$POD_BRIDGE_ADDR" "$POD_CHAIN_ID" "$BRIDGE_VERSION" "$BRIDGE_MERKLE_ROOT")
+  --sig "run(address,uint256,uint256,bytes32,uint64)" \
+  "$POD_BRIDGE_ADDR" "$POD_CHAIN_ID" "$BRIDGE_VERSION" "$BRIDGE_MERKLE_ROOT" "$FAULT_TOLERANCE")
 
 SOURCE_CHAIN_BRIDGE_ADDR=$(jq -sr 'map(.returns?.proxy?.value // empty) | map(select(. != "")) | last' <<< "$OUTPUT")
 


### PR DESCRIPTION
## Summary
- The `Deploy` script was computing `f = (n-1)/5` from the validator count, which gave `f=0` for 5 validators. This mismatched the Pod network's configured fault tolerance (e.g. `f=1`), causing the bridge contract to require all 5 validator signatures while Pod only guarantees `n-f` (4).
- Bridge claim e2e tests failed with `InsufficientValidatorWeight` because the proof contained 4 signatures but the contract required 5.
- Now `faultTolerance` is accepted as a parameter in `Deploy.run()` and passed via `FAULT_TOLERANCE` env var in `deploy_bridge.bash` (defaults to 0 for backward compatibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)