### PR TITLE
docs: fix outdated crate version in rust-sdk doc comment

### DIFF
--- a/rust-sdk/src/lib.rs
+++ b/rust-sdk/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pod-sdk = "0.1.0"
+//! pod-sdk = "0.5.0"
 //! ```
 //!
 //! ## Querying account balance


### PR DESCRIPTION
The doc comment at rust-sdk/src/lib.rs (lines 7–10) showed pod-sdk = "0.1.0" as the dependency version, but the actual crate version in rust-sdk/Cargo.toml is 0.5.0.