### PR TITLE
Document mark price and updated funding formula

### DIFF
--- a/doc/api-reference/market-configurations.md
+++ b/doc/api-reference/market-configurations.md
@@ -20,7 +20,7 @@ Each market on Pod is created with a set of protocol-level parameters that gover
 | Max Leverage | Maximum allowed leverage; set per market at creation |
 | Initial Margin | Required margin to open a position. Derived: `1 / Max Leverage` |
 | Maintenance Margin | Margin floor below which the position becomes eligible for liquidation. Derived: `Initial Margin / 2` |
-| Funding Interval | Funding rate calculation period (fixed at 8 hours network-wide) |
+| Interest Rate | Per-market funding constant, defaulting to 0.01% per 8 hours. See [Perpetuals → Funding](../protocol/perpetuals.md) |
 | Oracle | Price feed source (Pyth asset) |
 
 ## Live Markets

--- a/doc/protocol/perpetuals.md
+++ b/doc/protocol/perpetuals.md
@@ -42,7 +42,7 @@ funding_rate = clamp(
 ```
 
 - `oracle_price` - the spot price reported by the oracle for the underlying.
-- `impact_bid` / `impact_ask` - the best price at which a fixed impact volume can be bought / sold, computed with the batch auction logic.
+- `impact_bid` / `impact_ask` - the effective price a taker would get when opening a short / long position of size `impact_notional` (a per-market USD amount, defaulting to $10,000) against the current batch auction.
 - `saturate(x)` - `max(x, 0)`: each term contributes only when it pushes the perp away from spot.
 - `interest_rate` - a per-market constant, defaulting to 0.01% per 8 hours.
 - `max_funding_rate` - a per-market cap on the rate's magnitude, defaulting to 4% per hour.

--- a/doc/protocol/perpetuals.md
+++ b/doc/protocol/perpetuals.md
@@ -6,9 +6,58 @@ Pod supports perpetual futures as a native market type. Perpetual contracts trac
 
 Pod uses cross margin. There is a single collateral asset, USD, shared between perpetual and spot markets, so there is no need to transfer between the two.
 
+## Mark price
+
+Each perp market maintains a **mark price** — a smoothed reference price derived from the order book and the oracle. Mark price is the reference used for margin, liquidation, take-profit/stop-loss, and everything else related to leverage and PnL.
+
+It is recomputed every batch:
+
+```
+price_diff_ema = clamp(ema(clearing_or_mid − oracle_price, 3 min), max_premium)
+mark_price     = clamp(oracle_price + price_diff_ema, last_mark_price, mark_clamp_pct)
+```
+
+- `clearing_or_mid` — the batch's uniform clearing price if it matched, otherwise the order book mid price.
+- `ema(·, 3 min)` — a 3-minute exponential moving average of the gap between the book price and the oracle.
+- `max_premium` — a per-market bound; `price_diff_ema` is clamped to ±`max_premium` so mark cannot drift arbitrarily far from the oracle.
+- `mark_clamp_pct` — a per-market bound limiting how far `mark_price` can move from the previous batch's mark price in a single batch.
+
 ## Funding
 
-The funding rate is calculated every 8 hours. Payments are continuous and applied every batch - rather than settling in a single payment at the end of each period, the funding accrues incrementally across batches.
+Perpetuals use a funding mechanism to keep the mark price aligned with the underlying oracle price. The funding rate is recomputed and applied every batch — each open position pays or receives its share directly into cash, with no per-period lump payment.
+
+### Funding rate
+
+For each market, on every batch:
+
+```
+funding_rate = clamp(
+    interest_rate
+      + saturate(impact_bid − oracle_price)
+      − saturate(oracle_price − impact_ask),
+    max_funding_rate,
+)
+```
+
+- `oracle_price` — the spot price reported by the oracle for the underlying.
+- `impact_bid` / `impact_ask` — the best price at which a fixed impact volume can be bought / sold, computed with the batch auction logic.
+- `saturate(x)` — `max(x, 0)`: each term contributes only when it pushes the perp away from spot.
+- `interest_rate` — a per-market constant, defaulting to 0.01% per 8 hours.
+- `max_funding_rate` — a per-market cap on the rate's magnitude, defaulting to 4% per hour.
+- `funding_rate` is signed: positive means longs pay shorts, negative means shorts pay longs.
+
+When the perp trades at a premium (`impact_bid` above the oracle) the first `saturate` term is positive and longs pay; when it trades at a discount (`impact_ask` below the oracle) the second term dominates and shorts pay. The rate is computed and applied per batch — `interest_rate` and `max_funding_rate` are shown normalized to 8-hour and hourly figures only for readability.
+
+### Per-position payment
+
+Every batch, each open position settles funding into cash:
+
+```
+funding_payment = funding_rate × oracle_price × position.size
+realized_pnl   −= funding_payment
+```
+
+`position.size` is signed (long positive, short negative), so a positive `funding_rate` charges longs and credits shorts, and vice versa. After settlement, the position's unrealized PnL is pure price drift: `(mark − entry) × size`.
 
 ## Liquidation
 

--- a/doc/protocol/perpetuals.md
+++ b/doc/protocol/perpetuals.md
@@ -33,8 +33,8 @@ For each market, on every batch:
 ```
 funding_rate = clamp(
     interest_rate
-      + saturate(impact_bid − oracle_price)
-      − saturate(oracle_price − impact_ask),
+      + saturate((impact_bid − oracle_price) / oracle_price)
+      − saturate((oracle_price − impact_ask) / oracle_price),
     max_funding_rate,
 )
 ```

--- a/doc/protocol/perpetuals.md
+++ b/doc/protocol/perpetuals.md
@@ -8,23 +8,24 @@ Pod uses cross margin. There is a single collateral asset, USD, shared between p
 
 ## Mark price
 
-Each perp market maintains a **mark price** — a smoothed reference price derived from the order book and the oracle. Mark price is the reference used for margin, liquidation, take-profit/stop-loss, and everything else related to leverage and PnL.
+Each perp market maintains a **mark price** - a smoothed reference price derived from the order book and the oracle. Mark price is the reference used for margin, liquidation, take-profit/stop-loss, and everything else related to leverage and PnL.
 
 It is recomputed every batch:
 
 ```
-price_diff_ema = clamp(ema(clearing_or_mid − oracle_price, 3 min), max_premium)
-mark_price     = clamp(oracle_price + price_diff_ema, last_mark_price, mark_clamp_pct)
+price_diff_ema = clamp(ema(clearing_or_mid − oracle_price, 3 min), 0, max_premium)
+mark_price     = clamp(oracle_price + price_diff_ema, last_mark_price, mark_clamp_pct × last_mark_price)
 ```
 
-- `clearing_or_mid` — the batch's uniform clearing price if it matched, otherwise the order book mid price.
-- `ema(·, 3 min)` — a 3-minute exponential moving average of the gap between the book price and the oracle.
-- `max_premium` — a per-market bound; `price_diff_ema` is clamped to ±`max_premium` so mark cannot drift arbitrarily far from the oracle.
-- `mark_clamp_pct` — a per-market bound limiting how far `mark_price` can move from the previous batch's mark price in a single batch.
+- `clamp(x, center, half_width)` - clips `x` to `[center − half_width, center + half_width]`.
+- `clearing_or_mid` - the batch's uniform clearing price if it matched, otherwise the order book mid price.
+- `ema(·, 3 min)` - a 3-minute exponential moving average of the gap between the book price and the oracle.
+- `max_premium` - a per-market bound; `price_diff_ema` is clamped to ±`max_premium` so mark cannot drift arbitrarily far from the oracle.
+- `mark_clamp_pct` - a per-market bound limiting how far `mark_price` can move from the previous batch's mark price in a single batch, expressed as a fraction of `last_mark_price`.
 
 ## Funding
 
-Perpetuals use a funding mechanism to keep the mark price aligned with the underlying oracle price. The funding rate is recomputed and applied every batch — each open position pays or receives its share directly into cash, with no per-period lump payment.
+Perpetuals use a funding mechanism to keep the mark price aligned with the underlying oracle price. The funding rate is recomputed and applied every batch - each open position pays or receives its share directly into cash, with no per-period lump payment.
 
 ### Funding rate
 
@@ -35,18 +36,19 @@ funding_rate = clamp(
     interest_rate
       + saturate((impact_bid − oracle_price) / oracle_price)
       − saturate((oracle_price − impact_ask) / oracle_price),
+    0,
     max_funding_rate,
 )
 ```
 
-- `oracle_price` — the spot price reported by the oracle for the underlying.
-- `impact_bid` / `impact_ask` — the best price at which a fixed impact volume can be bought / sold, computed with the batch auction logic.
-- `saturate(x)` — `max(x, 0)`: each term contributes only when it pushes the perp away from spot.
-- `interest_rate` — a per-market constant, defaulting to 0.01% per 8 hours.
-- `max_funding_rate` — a per-market cap on the rate's magnitude, defaulting to 4% per hour.
+- `oracle_price` - the spot price reported by the oracle for the underlying.
+- `impact_bid` / `impact_ask` - the best price at which a fixed impact volume can be bought / sold, computed with the batch auction logic.
+- `saturate(x)` - `max(x, 0)`: each term contributes only when it pushes the perp away from spot.
+- `interest_rate` - a per-market constant, defaulting to 0.01% per 8 hours.
+- `max_funding_rate` - a per-market cap on the rate's magnitude, defaulting to 4% per hour.
 - `funding_rate` is signed: positive means longs pay shorts, negative means shorts pay longs.
 
-When the perp trades at a premium (`impact_bid` above the oracle) the first `saturate` term is positive and longs pay; when it trades at a discount (`impact_ask` below the oracle) the second term dominates and shorts pay. The rate is computed and applied per batch — `interest_rate` and `max_funding_rate` are shown normalized to 8-hour and hourly figures only for readability.
+When the perp trades at a premium (`impact_bid` above the oracle) the first `saturate` term is positive and longs pay; when it trades at a discount (`impact_ask` below the oracle) the second term dominates and shorts pay. The rate is computed and applied per batch - `interest_rate` and `max_funding_rate` are shown normalized to 8-hour and hourly figures only for readability.
 
 ### Per-position payment
 


### PR DESCRIPTION
Add mark-price derivation (EMA-smoothed oracle premium with clamps) and rewrite funding to use the impact-bid/ask formula with one-sided saturate terms. Per-position payment is now per-batch with no elapsed scaling. Replace the stale "Funding Interval" market parameter with "Interest Rate".