### PR TITLE
docs: fix funding rate clamp, payment formula, and market order clearing price

### DIFF
--- a/doc/protocol/orderbook.md
+++ b/doc/protocol/orderbook.md
@@ -36,6 +36,8 @@ At the end of each batch interval, the matching engine runs a double auction usi
 
 All matched orders execute at the same uniform price. No participant gets a better or worse price based on when their order arrived within the batch.
 
+Market orders do not influence the clearing price — only limit orders at the margin determine it. If the marginal matched order on one side is a market order, the clearing price equals the limit price from the other side alone. If no limit orders were matched at all, the previous batch's clearing price carries over.
+
 ### Batch Deadline
 
 The `deadline` parameter in `submitOrder` specifies the latest batch the user wants their order included in. The order can be included in any batch up to and including the deadline batch — so pushing `deadline` further into the future widens the window of batches the order can land in, it does not delay execution.

--- a/doc/protocol/perpetuals.md
+++ b/doc/protocol/perpetuals.md
@@ -34,7 +34,7 @@ funding_rate = clamp(
     interest_rate
       + saturate((impact_bid − oracle_price) / oracle_price)
       − saturate((oracle_price − impact_ask) / oracle_price),
-    0,
+    −max_funding_rate,
     max_funding_rate,
 )
 ```
@@ -50,11 +50,11 @@ When the perp trades at a premium (`impact_bid` above the oracle) the first `sat
 
 ### Per-position payment
 
-Every batch, each open position settles funding into cash:
+Every batch, each open position settles funding into cash. Because `interest_rate` and `max_funding_rate` are expressed per `funding_window` (8 hours by default), the payment is prorated to the actual time elapsed since the last batch:
 
 ```
-funding_payment = funding_rate × oracle_price × position.size
+funding_payment = funding_rate × oracle_price × position.size × (elapsed / funding_window)
 realized_pnl   −= funding_payment
 ```
 
-`position.size` is signed (long positive, short negative), so a positive `funding_rate` charges longs and credits shorts, and vice versa. After settlement, the position's unrealized PnL is pure price drift: `(mark − entry) × size`.
+`position.size` is signed (long positive, short negative), so a positive `funding_rate` charges longs and credits shorts, and vice versa. A position held for exactly one `funding_window` pays `funding_rate × oracle_price × position.size` in total. After settlement, the position's unrealized PnL is pure price drift: `(mark − entry) × size`.


### PR DESCRIPTION
- **\`perpetuals.md\`**: Funding rate clamp lower bound corrected from \`0\` to \`−max_funding_rate\` — the formula contradicted the text below it which already described negative rates.
- **\`perpetuals.md\`**: Funding payment formula now includes \`× (elapsed / funding_window)\` — the proration factor was missing, making the formula independent of batch duration.
- **\`orderbook.md\`**: Added a paragraph after the clearing algorithm explaining that market orders don't influence the clearing price, and what happens when only one side has a limit order at the margin or no limit orders were matched at all.