### PR TITLE
Fix missing Address import

### DIFF
--- a/doc/api-reference/guides/place-a-spot-order.md
+++ b/doc/api-reference/guides/place-a-spot-order.md
@@ -58,7 +58,7 @@ console.log("Order tx:", tx.hash);
 use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol;
-use alloy::primitives::{U256, I256, FixedBytes};
+use alloy::primitives::{Address, U256, I256, FixedBytes};
 
 sol! {
     #[sol(rpc)]


### PR DESCRIPTION
The Rust example uses the `Address` type but does not import it from `alloy::primitives`.

Added `Address` to the primitives import list so the snippet compiles correctly.