### PR TITLE
ts-sdk: delegated wallet, mint faucet, resource refresh

### DIFF
--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -16,6 +16,8 @@ import { enrichPositions } from "./sync/positions-live.js";
 export interface PodTradeClientOptions {
   restUrl: string;
   wsUrl: string;
+  /** Node JSON-RPC HTTP endpoint — needed only for tx features (e.g. mint). */
+  rpcUrl?: string;
   fetch?: typeof fetch;
   WebSocket?: WebSocketCtor;
   reconnect?: { maxDelayMs?: number; idleTimeoutMs?: number };
@@ -32,8 +34,12 @@ export class PodTradeClient {
   readonly ws: PodWsClient;
   private readonly ctx: SyncContext;
   private readonly cache = new Map<string, Destroyable & object>();
+  private readonly rpcUrl?: string;
+  private readonly fetchFn?: typeof fetch;
 
   constructor(opts: PodTradeClientOptions) {
+    this.rpcUrl = opts.rpcUrl;
+    this.fetchFn = opts.fetch;
     this.rest = new PodRestClient({ restUrl: opts.restUrl, fetch: opts.fetch });
     this.ws = new PodWsClient({
       wsUrl: opts.wsUrl,
@@ -50,6 +56,46 @@ export class PodTradeClient {
   }
 
   connect(): void { this.ws.connect(); }
+
+  /**
+   * Re-seed an account's cached resources (positions, balances — and anything
+   * derived from them) from REST. For out-of-band mutations the streams don't
+   * announce; stream-covered state needs no manual refresh.
+   */
+  refresh(account: Address): void {
+    for (const key of [`positions:${account}`, `balances:${account}`]) {
+      const r = this.cache.get(key);
+      if (r instanceof BaseResource) r.refresh();
+    }
+  }
+
+  /**
+   * Faucet mint (test environments where the node sets `minting_allowed`):
+   * credit `to` — by default straight into the CLOB — wait for the receipt,
+   * then refresh the account's cached resources, since a mint emits no account
+   * tick and would otherwise only appear on the next periodic resync. Mint txs
+   * are gas-exempt and signer-irrelevant (signed by a one-shot throwaway key
+   * inside the SDK), so no wallet or delegation is needed. Requires `rpcUrl`
+   * in the client options; the /write entry is loaded on demand.
+   */
+  async mint(
+    to: Address,
+    tokens: Array<{ token?: Address; amount: bigint }>,
+    opts?: { depositToClob?: boolean; onSubmitted?: (hash: string) => void },
+  ): Promise<{ transactionHash: string }> {
+    if (!this.rpcUrl) throw new Error("PodTradeClient.mint requires `rpcUrl` in the client options");
+    const { mint } = await import("./write/index.js");
+    const receipt = await mint({
+      rpcUrl: this.rpcUrl,
+      to,
+      tokens,
+      depositToClob: opts?.depositToClob,
+      onSubmitted: opts?.onSubmitted,
+      fetch: this.fetchFn,
+    });
+    this.refresh(to);
+    return receipt;
+  }
 
   close(): void {
     for (const r of this.cache.values()) r.destroy();

--- a/ts-sdk/src/stores/resource.ts
+++ b/ts-sdk/src/stores/resource.ts
@@ -6,6 +6,8 @@ export interface Resource<T> {
   get(): T | undefined;
   subscribe(listener: () => void): () => void;
   ready(): Promise<T>;
+  /** Restart the source for a fresh seed (optional — see BaseResource). */
+  refresh?(): void;
   readonly error?: Error;
 }
 
@@ -63,6 +65,18 @@ export class BaseResource<T> implements Resource<T> {
   /** Force teardown (used by the client on close). */
   destroy(): void {
     this.stop();
+  }
+
+  /**
+   * Tear down and restart the source, forcing a fresh seed while keeping
+   * subscribers and the current value (no flicker — the old snapshot stays
+   * until the new seed lands). No-op when the resource isn't running. For
+   * out-of-band mutations the streams don't announce (e.g. a faucet mint).
+   */
+  refresh(): void {
+    if (!this.started) return;
+    this.stop();
+    this.ensureStarted();
   }
 
   private ensureStarted(): void {

--- a/ts-sdk/src/write/delegation.ts
+++ b/ts-sdk/src/write/delegation.ts
@@ -1,0 +1,113 @@
+// Ephemeral-key delegation, mirroring node/src/delegation/mod.rs (stateless):
+// the master wallet signs one EIP-712 `DelegationAuth { delegate, validUntil }`
+// authorizing a freshly generated ephemeral key; every CLOB tx is then wrapped
+// in the gas-exempt `delegated(master, validUntil, signature, inner)` envelope
+// and signed by that key. No on-chain registration — the cert rides in each tx.
+//
+// SECURITY INVARIANT: the ephemeral private key exists ONLY inside the closure
+// created by createDelegatedWallet() — it is never exported, never persisted,
+// never attached to any object that leaves this module. The only capability a
+// DelegatedWallet exposes is submit(); "logging out" is dropping the object.
+// Keep it that way.
+
+import { createWalletClient, defineChain, encodeFunctionData, http, parseAbi, recoverTypedDataAddress } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import type { Address, Hash, Hex } from "../types/public.js";
+import { sendRawTransaction, type PodTxRequest } from "./index.js";
+
+/** EIP-712 payload the master signs (domain "pod delegation" v1). */
+export function delegationTypedData(delegate: Address, validUntil: bigint, chainId: number) {
+  return {
+    domain: { name: "pod delegation", version: "1", chainId },
+    types: { DelegationAuth: [
+      { name: "delegate", type: "address" },
+      { name: "validUntil", type: "uint64" },
+    ] },
+    primaryType: "DelegationAuth",
+    message: { delegate, validUntil },
+  } as const;
+}
+
+export type DelegationTypedData = ReturnType<typeof delegationTypedData>;
+
+const DELEGATED_ABI = parseAbi([
+  "function delegated(address master, uint64 validUntil, bytes signature, bytes inner)",
+]);
+
+/** A trading session: public cert facts + the one capability, submit(). */
+export interface DelegatedWallet {
+  readonly master: Address;
+  readonly delegate: Address;
+  /** Cert expiry in MICROSECONDS — must cover every inner intent deadline. */
+  readonly validUntil: bigint;
+  /** Wrap `tx` in the delegated envelope, sign with the ephemeral key, and
+   * broadcast (raw send, CLOB revert reasons decoded). Returns the tx hash. */
+  submit(tx: PodTxRequest): Promise<Hash>;
+}
+
+export interface CreateDelegatedWalletParams {
+  master: Address;
+  chainId: number;
+  /** Node JSON-RPC HTTP endpoint (nonce, gas price, broadcast). */
+  rpcUrl: string;
+  /** The master wallet's typed-data prompt (the one signature of the flow). */
+  signTypedData: (td: DelegationTypedData) => Promise<Hex>;
+  /** Delegation lifetime in ms; must cover every intent deadline issued during it. */
+  ttlMs: number;
+  fetch?: typeof fetch;
+}
+
+/**
+ * Create a session: generate an ephemeral key, have the master sign the
+ * delegation via `signTypedData`, and verify the returned signature actually
+ * recovers to `master` before trusting it (catches a wrong active account in
+ * the wallet at login instead of a confusing node revert later).
+ */
+export async function createDelegatedWallet(p: CreateDelegatedWalletParams): Promise<DelegatedWallet> {
+  const account = privateKeyToAccount(generatePrivateKey());
+  const validUntil = (BigInt(Date.now()) + BigInt(p.ttlMs)) * 1000n; // µs
+  const typedData = delegationTypedData(account.address, validUntil, p.chainId);
+  const signature = await p.signTypedData(typedData);
+  const recovered = await recoverTypedDataAddress({ ...typedData, signature });
+  if (recovered.toLowerCase() !== p.master.toLowerCase()) {
+    throw new Error(`delegation signed by ${recovered}, not ${p.master} — is the right account active?`);
+  }
+
+  const chain = defineChain({
+    id: p.chainId, name: `pod-${p.chainId}`,
+    nativeCurrency: { name: "pETH", symbol: "pETH", decimals: 18 },
+    rpcUrls: { default: { http: [p.rpcUrl] } },
+  });
+  const client = createWalletClient({ account, chain, transport: http(p.rpcUrl) });
+  const doFetch = p.fetch ?? fetch;
+
+  const submit = async (tx: PodTxRequest): Promise<Hash> => {
+    // Refuse to sign with a cert that can't cover a fresh intent deadline
+    // (~15 min out) — the node would reject the tx as expired anyway.
+    if (validUntil <= (BigInt(Date.now()) + 20n * 60_000n) * 1000n) {
+      throw new Error("delegation expired — re-authorize the wallet");
+    }
+    const data = encodeFunctionData({
+      abi: DELEGATED_ABI,
+      functionName: "delegated",
+      args: [p.master, validUntil, signature, tx.data],
+    });
+    const maxFeePerGas = BigInt(await rpc(p.rpcUrl, doFetch, "eth_gasPrice"));
+    const prepared = await client.prepareTransactionRequest({ ...tx, data, account, chain, maxFeePerGas });
+    const serialized = await client.signTransaction(prepared as never);
+    return sendRawTransaction(p.rpcUrl, serialized, { fetch: doFetch });
+  };
+
+  return Object.freeze({ master: p.master, delegate: account.address, validUntil, submit });
+}
+
+async function rpc(rpcUrl: string, doFetch: typeof fetch, method: string): Promise<string> {
+  const res = await doFetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [] }),
+  });
+  const json = (await res.json()) as { result?: string; error?: { message?: string } };
+  if (json.error || json.result === undefined) throw new Error(json.error?.message ?? `${method} failed`);
+  return json.result;
+}

--- a/ts-sdk/src/write/index.ts
+++ b/ts-sdk/src/write/index.ts
@@ -3,10 +3,15 @@
 // + broadcasts the returned request with whatever wallet it has
 // (walletClient.sendTransaction / eth_sendTransaction / Privy).
 //
-// Uses viem only as an ABI/keccak encoder (not for signing), and lives in this
-// separate `/write` entry so read-only consumers never bundle it.
+// Two deliberate exceptions hold keys, both scoped to this `/write` entry so
+// read-only consumers never bundle signing code:
+//  - `mint` (below): the faucet is gas-exempt and signer-irrelevant, so it
+//    signs with a one-shot throwaway key.
+//  - `createDelegatedWallet` (./delegation.js): custody of the ephemeral
+//    trading key, closed over — see the invariant there.
 
 import { decodeAbiParameters, encodeAbiParameters, encodeFunctionData, keccak256, parseAbi } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import type { Address, Hash, Hex, MarketId } from "../types/public.js";
 
 /** The CLOB precompile (chain id 1293 / 0x50d). */
@@ -530,6 +535,73 @@ export async function waitForReceipt(
   }
 }
 
+// --- mint faucet (test environments — node/src/mint.rs) ----------------------
+//
+// Anyone may mint tokens to any address when the node's `minting_allowed` flag
+// is set (and its mint-admin list is empty). Mint txs are gas-exempt and the
+// signer is irrelevant — only the recipient matters — so this signs with a
+// fresh throwaway key per call; no wallet, no funds, no delegation needed.
+
+/** The Mint contract (`node/src/mint.rs`). */
+export const MINT_ADDRESS: Address = "0x00000000000000000000000000000000000fFFFf";
+/** The native USD (cash) token — `trading/src/constants.rs` NATIVE_ADDRESS. */
+export const NATIVE_USD_ADDRESS: Address = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+const MINT_ABI = parseAbi([
+  "function mint(address to, (address token, uint256 amount)[] tokens, bool depositToClob)",
+]);
+
+export interface MintParams {
+  rpcUrl: string;
+  /** Chain id for the tx; fetched via `eth_chainId` when omitted. */
+  chainId?: number;
+  to: Address;
+  /** 1e18-scaled amounts; `token` defaults to the native USD (cash) token. */
+  tokens: Array<{ token?: Address; amount: bigint }>;
+  /** Deposit into the CLOB balance (default) instead of crediting the EOA. */
+  depositToClob?: boolean;
+  /** Called with the tx hash once the node accepts it (before confirmation). */
+  onSubmitted?: (hash: Hash) => void;
+  fetch?: typeof fetch;
+}
+
+/** Mint tokens to `to` and wait for the receipt. Throws {@link PodTxRevertError}
+ * on rejection (e.g. "Minting is disabled") and Error on on-chain revert. */
+export async function mint(p: MintParams): Promise<TxReceipt> {
+  const doFetch = p.fetch ?? fetch;
+  const rpc = async (method: string): Promise<string> => {
+    const res = await doFetch(p.rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [] }),
+    });
+    const json = (await res.json()) as { result?: string; error?: { message?: string } };
+    if (json.error || json.result === undefined) throw new Error(json.error?.message ?? `${method} failed`);
+    return json.result;
+  };
+  const chainId = p.chainId ?? Number(await rpc("eth_chainId"));
+  const maxFeePerGas = BigInt(await rpc("eth_gasPrice"));
+  const signer = privateKeyToAccount(generatePrivateKey());
+  const data = encodeFunctionData({
+    abi: MINT_ABI,
+    functionName: "mint",
+    args: [
+      p.to,
+      p.tokens.map((t) => ({ token: t.token ?? NATIVE_USD_ADDRESS, amount: t.amount })),
+      p.depositToClob ?? true,
+    ],
+  });
+  const serialized = await signer.signTransaction({
+    to: MINT_ADDRESS, data, value: 0n, chainId, type: "eip1559",
+    maxFeePerGas, maxPriorityFeePerGas: 0n, gas: 1_000_000n, nonce: 0,
+  });
+  const hash = await sendRawTransaction(p.rpcUrl, serialized, { fetch: doFetch });
+  p.onSubmitted?.(hash);
+  const receipt = await waitForReceipt(p.rpcUrl, hash, { fetch: doFetch });
+  if (receipt.status === "reverted") throw new Error(`mint reverted on-chain (${hash.slice(0, 10)}…)`);
+  return receipt;
+}
+
 /**
  * Deterministic order id: `keccak256(abi.encode(signer, nonce, sequence))`,
  * matching the engine (`trading/src/lib.rs`). `sequence` is the 0-based index
@@ -545,3 +617,8 @@ export function deriveOrderId(signer: Address, nonce: number, sequence = 0): Has
     ),
   ) as Hash;
 }
+
+export {
+  createDelegatedWallet, delegationTypedData,
+  type CreateDelegatedWalletParams, type DelegatedWallet, type DelegationTypedData,
+} from "./delegation.js";


### PR DESCRIPTION
## Summary

Adds the key-holding tx features to the `/write` entry (scoped there so read-only consumers never bundle signing code), plus the invalidation plumbing they need:

- **Delegated wallet** (`createDelegatedWallet`): the master wallet signs one EIP-712 `DelegationAuth { delegate, validUntil }` authorizing a freshly generated ephemeral key; every CLOB tx is then wrapped in the gas-exempt `delegated(master, validUntil, signature, inner)` envelope and signed by that key (stateless — the cert rides in each tx, per `node/src/delegation`). The private key is closed over inside the SDK: the only exposed capability is `submit()`, nothing is persisted, and the signature is verified to recover to the claimed master before it's trusted. `submit()` refuses to sign with a cert that can't cover a fresh intent deadline.
- **Mint faucet** (`mint`, `client.mint`): for environments whose node sets `minting_allowed`. Gas-exempt and signer-irrelevant, so it signs with a one-shot throwaway key — no wallet, funds, or delegation needed. `client.mint()` waits for the receipt and then invalidates the recipient's cached balances/positions itself, since mints emit no account tick and would otherwise only appear on the next 60s resync.
- **`Resource.refresh()`** and **`client.refresh(account)`**: restart a resource's source for a fresh seed (keeping subscribers and the current value — no flicker), for out-of-band mutations the streams don't announce.
- Client options gain `rpcUrl` (node JSON-RPC HTTP) for tx features; the `/write` entry is dynamically imported by `client.mint()` so the read bundle stays lean.

## Verification

- `npm run typecheck` and `npm run build` pass in `ts-sdk/`.
- Verified end-to-end against staging: a fresh master/ephemeral pair's cert passes node verification (a delegated cancel fails only with "Unknown orderbook id" on a garbage orderbook), and a $10k mint lands as CLOB cash for the recipient.
- Consumed by the trading app (`frontend#worktree-privy`) for the login → enable-trading → trade/mint flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)