### PR TITLE
docs(orderbook): TriggerGrouping Position renamed to Asset

### DIFF
--- a/doc/api-reference/applications-precompiles/orderbook.md
+++ b/doc/api-reference/applications-precompiles/orderbook.md
@@ -61,12 +61,16 @@ contract Orderbook {
     // Trigger kind for a TP/SL trigger (perp markets only).
     enum TriggerType { TakeProfit, StopLoss }
 
-    // Whether a trigger is bound to the bidder's position on the pair.
+    // Exposure-association for a trigger.
     // None: standalone — removed only by a user cancel, TTL expiry, or its own fire.
-    // Position: the venue cancels the armed trigger (and any resting synthetic order
-    //           it already produced) at the end of the batch in which the bidder's
-    //           position on the pair reaches size 0.
-    enum TriggerGrouping { None, Position }
+    // Asset: binds the trigger to the asset the market type implies — on perp
+    //        markets the venue cancels the armed trigger (and any resting synthetic
+    //        order it already produced) at the end of the batch in which the
+    //        bidder's position on the pair reaches size 0; on spot markets it
+    //        cancels the armed trigger when the bidder's base-asset holdings hit 0.
+    //        (Renamed from `Position`; same ABI value — older nodes report it as
+    //        `position` in RPC responses.)
+    enum TriggerGrouping { None, Asset }
 
     // --- Events ---
 
@@ -240,7 +244,7 @@ contract Orderbook {
      * @param limitPrice The limit price of the synthetic order produced when the trigger fires.
      * @param triggerPrice The mark-price threshold that fires the trigger.
      * @param triggerType TakeProfit or StopLoss.
-     * @param grouping Whether the trigger is bound to the bidder's position on the pair (see TriggerGrouping).
+     * @param grouping Whether the trigger is bound to the bidder's exposure on the pair (see TriggerGrouping).
      * @param deadline The latest batch this intent may be included in, in microseconds. Must be a multiple of the market's `auction_interval`.
      * @param ttl The "Time To Live" duration in microseconds; how long the armed trigger remains active.
      * @param reduceOnly If true, the synthetic order will only reduce an existing position.

--- a/doc/api-reference/guides/submit-a-batch-order.md
+++ b/doc/api-reference/guides/submit-a-batch-order.md
@@ -11,7 +11,7 @@ Each entry in `inner` is the full ABI-encoded calldata of a single-intent call (
 1. ABI-encode each single-intent call (entry order, take-profit trigger, stop-loss trigger).
 2. Pass them as the `inner` array to `submitBatch`.
 
-The example opens a 5 NVDA long at $140 and arms two position-grouped, reduce-only triggers — a take-profit that sells at $160 and a stop-loss that sells at $120.
+The example opens a 5 NVDA long at $140 and arms two asset-grouped (position-bound), reduce-only triggers — a take-profit that sells at $160 and a stop-loss that sells at $120.
 
 {% tabs %}
 {% tab title="TypeScript (ethers.js)" %}
@@ -45,13 +45,13 @@ const entry = orderbook.interface.encodeFunctionData("submitOrder", [
 // 2. Take-profit: sell 5 NVDA when price reaches $160 (reduceOnly, tied to the position)
 const takeProfit = orderbook.interface.encodeFunctionData("submitTrigger", [
   nvdaPerpId, -size, ethers.parseEther("160"), ethers.parseEther("160"),
-  0 /* TakeProfit */, 1 /* Position */, deadline, ttl, true, false,
+  0 /* TakeProfit */, 1 /* Asset */, deadline, ttl, true, false,
 ]);
 
 // 3. Stop-loss: sell 5 NVDA when price drops to $120 (reduceOnly, tied to the position)
 const stopLoss = orderbook.interface.encodeFunctionData("submitTrigger", [
   nvdaPerpId, -size, ethers.parseEther("120"), ethers.parseEther("120"),
-  1 /* StopLoss */, 1 /* Position */, deadline, ttl, true, false,
+  1 /* StopLoss */, 1 /* Asset */, deadline, ttl, true, false,
 ]);
 
 // Submit all three as one atomic envelope
@@ -73,7 +73,7 @@ sol! {
     contract Orderbook {
         enum OrderType { Limit, Market }
         enum TriggerType { TakeProfit, StopLoss }
-        enum TriggerGrouping { None, Position }
+        enum TriggerGrouping { None, Asset }
         function submitOrder(
             bytes32 orderbookId, int256 size, uint256 price,
             OrderType orderType, uint128 deadline, uint128 ttl,
@@ -125,7 +125,7 @@ let take_profit = Orderbook::submitTriggerCall {
     limitPrice: U256::from(160) * one_e18,
     triggerPrice: U256::from(160) * one_e18,
     triggerType: Orderbook::TriggerType::TakeProfit,
-    grouping: Orderbook::TriggerGrouping::Position,
+    grouping: Orderbook::TriggerGrouping::Asset,
     deadline, ttl, reduceOnly: true, ioc: false,
 }.abi_encode();
 
@@ -136,7 +136,7 @@ let stop_loss = Orderbook::submitTriggerCall {
     limitPrice: U256::from(120) * one_e18,
     triggerPrice: U256::from(120) * one_e18,
     triggerType: Orderbook::TriggerType::StopLoss,
-    grouping: Orderbook::TriggerGrouping::Position,
+    grouping: Orderbook::TriggerGrouping::Asset,
     deadline, ttl, reduceOnly: true, ioc: false,
 }.abi_encode();
 

--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -669,7 +669,7 @@ paths:
                       limit_price: "0x115ad84a8ad03c00000"
                       trigger_price: "0x120a871cc0020a00000"
                       trigger_type: "take_profit"
-                      grouping: "position"
+                      grouping: "asset"
                       reduce_only: true
                       ioc: false
                       deadline: "1704153600000000"
@@ -1745,11 +1745,13 @@ components:
 
     TriggerGrouping:
       type: string
-      enum: [none, position]
+      enum: [none, asset, position]
       description: |
-        Whether a trigger (and any synthetic order it produces) is bound to the bidder's position on the pair:
+        Whether a trigger (and any synthetic order it produces) is bound to the bidder's exposure on the pair:
         - `none`: standalone — the trigger is removed only by a user cancel, TTL expiry, or its own fire; any synthetic order it produced survives independently
-        - `position`: position-bound — the venue removes the armed trigger *and* any resting synthetic order it produced once the bidder's position on the pair reaches size 0
+        - `asset`: exposure-bound — on perp markets the venue removes the armed trigger *and* any resting synthetic order it produced once the bidder's position on the pair reaches size 0; on spot markets, once the bidder's base-asset holdings reach 0
+
+        `asset` was formerly named `position` (same semantics, same ABI value); nodes running older builds still emit `position` and clients should treat the two as equivalent.
 
         Omitted from an `Order` response when it is the default `none`.
 


### PR DESCRIPTION
The node renamed the `TriggerGrouping` enum variant `Position` → `Asset` (same ABI value; on perps it still binds the trigger to the position on the pair, on spot markets it binds to the bidder's base-asset holdings). Upgraded nodes serialize it as `"asset"` in RPC responses; older nodes emit `"position"`.

Updates the orderbook precompile reference, the `submitBatch` guide examples, and the OpenAPI `TriggerGrouping` schema (documents both wire values and their equivalence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)