### PR TITLE
docs(rpc): ob_getOrders total_count is opt-in via with_total

### DIFF
--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -340,6 +340,7 @@ paths:
                     - orderbook_id: "0x0000000000000000000000000000000000000000000000000000000000000001"
                       limit: 10
                       status: "active"
+                      with_total: true
       responses:
         '200':
           description: Object containing orders array and pagination cursor
@@ -357,7 +358,7 @@ paths:
                         items: { $ref: '#/components/schemas/Order' }
                       total_count:
                         type: integer
-                        description: Total number of orders matching the query
+                        description: Total number of orders matching the query, regardless of pagination. Present only when the request set `with_total` (omitted otherwise, not null). Older nodes always return it.
                       next_cursor:
                         type: string
                         nullable: true
@@ -2238,6 +2239,9 @@ components:
         with_fills:
           type: boolean
           description: When true, include each order's per-batch partial `fills` array in the response. Defaults to false.
+        with_total:
+          type: boolean
+          description: When true, compute and return `total_count`. Defaults to false — the count walks every order the account ever placed (expensive for high-churn accounts), and cursor pagination does not need it. Nodes running builds predating this flag ignore it and always return `total_count`.
 
     FillsQuery:
       type: object


### PR DESCRIPTION
Documents the ob_getOrders change from podnetwork/pod#1540: the request object gains an opt-in `with_total` flag, and `total_count` is returned only when it is set (omitted otherwise, not null) — the count walks every order the account ever placed, which is expensive for high-churn accounts, and cursor pagination never needed it.

Updates the OrdersQuery schema, the response schema's `total_count` description, and the request example (which shows `total_count` in its response and now requests it). The `total_count` fields of ob_getTriggers and ob_getBackstopTransfers are unchanged. Both directions of version skew are noted: older nodes ignore the flag and always return the total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)