### PR TITLE
feat(bridge): version-upgrade forge script; clean up code-upgrade script

### DIFF
--- a/protocol/script/UpdateBridgeValidatorConfig.s.sol
+++ b/protocol/script/UpdateBridgeValidatorConfig.s.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {Bridge} from "pod-protocol/Bridge.sol";
+
+/**
+ * @notice Bridge version upgrade (validator rotation): submits the single
+ *         atomic `updateValidatorConfig` call that rotates the validator set,
+ *         bumps the domain-separator version (killing all previous
+ *         certificates), and installs the Merkle root that keeps pre-upgrade
+ *         withdrawals claimable.
+ *
+ *         Inputs via env (driven by pod's scripts/bridge-upgrade.sh, which
+ *         computes NEW_MERKLE_ROOT itself with `node bridge-merkle-root`):
+ *           BRIDGE_PROXY             proxy address
+ *           NEW_VERSION              new version (> current; fits uint32)
+ *           NEW_RESILIENCE           new adversarial resilience
+ *           NEW_MERKLE_ROOT          root over all pre-upgrade withdrawal claims
+ *           ADD_VALIDATORS           comma-separated addresses (optional)
+ *           REMOVE_VALIDATORS        comma-separated addresses (optional)
+ *           ALLOW_EMPTY_MERKLE_ROOT  "true" to permit bytes32(0) (a bridge
+ *                                    with zero historical withdrawals only)
+ */
+contract UpdateBridgeValidatorConfig is Script {
+    function run() external {
+        Bridge bridge = Bridge(vm.envAddress("BRIDGE_PROXY"));
+        uint256 newVersion = vm.envUint("NEW_VERSION");
+        uint64 newResilience = uint64(vm.envUint("NEW_RESILIENCE"));
+        bytes32 newMerkleRoot = vm.envBytes32("NEW_MERKLE_ROOT");
+        address[] memory addValidators = vm.envOr("ADD_VALIDATORS", ",", new address[](0));
+        address[] memory removeValidators = vm.envOr("REMOVE_VALIDATORS", ",", new address[](0));
+
+        uint256 oldVersion = bridge.version();
+        require(newVersion > oldVersion, "NEW_VERSION must exceed the current version");
+        require(newVersion <= type(uint32).max, "NEW_VERSION must fit uint32 (merkle proof encoding)");
+        if (newMerkleRoot == bytes32(0)) {
+            require(
+                vm.envOr("ALLOW_EMPTY_MERKLE_ROOT", false),
+                "zero merkle root would strand every pre-upgrade withdrawal; set ALLOW_EMPTY_MERKLE_ROOT=true only for a bridge with no withdrawals"
+            );
+        }
+
+        console.log("Bridge:", address(bridge));
+        console.log("Version:", oldVersion, "->", newVersion);
+        console.log("Resilience ->", newResilience);
+        console.log("Merkle root:");
+        console.logBytes32(newMerkleRoot);
+        console.log("Adding %d / removing %d validators", addValidators.length, removeValidators.length);
+
+        vm.startBroadcast();
+        bridge.updateValidatorConfig(newResilience, newVersion, newMerkleRoot, addValidators, removeValidators);
+        vm.stopBroadcast();
+
+        require(bridge.version() == newVersion, "version not updated");
+        require(bridge.merkleRoot() == newMerkleRoot, "merkle root not updated");
+        console.log("Validator config updated.");
+    }
+}

--- a/protocol/script/UpgradeBridge.s.sol
+++ b/protocol/script/UpgradeBridge.s.sol
@@ -10,12 +10,13 @@ import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.s
 
 contract UpgradeBridge is Script {
     /**
+     * @notice Code upgrade only: deploys a fresh implementation and swaps the
+     *         proxy to it, preserving all storage. Does NOT touch the version,
+     *         validator set, or merkle root — for a version upgrade (validator
+     *         rotation) use UpdateBridgeValidatorConfig.s.sol.
      * @param proxyAddr The TransparentUpgradeableProxy address.
-     * @param newMerkleRoot Merkle root covering all unprocessed claims from before the upgrade.
-     *        Compute off-chain from pending claim tx hashes using the OLD hash scheme.
-     *        Pass bytes32(0) if there are no pending claims.
      */
-    function run(address proxyAddr, bytes32 newMerkleRoot) external {
+    function run(address proxyAddr) external {
         Bridge bridge = Bridge(proxyAddr);
 
         // Read ProxyAdmin from ERC-1967 admin slot
@@ -39,8 +40,6 @@ contract UpgradeBridge is Script {
         // 2. Upgrade proxy to new implementation (no reinitializer needed — storage layout is identical)
         ProxyAdmin(proxyAdminAddr).upgradeAndCall(ITransparentUpgradeableProxy(proxyAddr), address(newImpl), "");
         console.log("Proxy upgraded");
-
-        console.log("Validator config updated");
 
         vm.stopBroadcast();
     }

--- a/protocol/script/upgrade_bridge.sh
+++ b/protocol/script/upgrade_bridge.sh
@@ -5,21 +5,20 @@ set -euo pipefail
 : "${BRIDGE_ADMIN_SECRET:?}"
 : "${BRIDGE_PROXY_ADDRESS:?}" # Bridge proxy address from initial deployment
 
-# Merkle root for pending claims from the old hash scheme.
-# Set to 0x0 if there are no pending claims.
-MERKLE_ROOT=${UPGRADE_MERKLE_ROOT:-0x0000000000000000000000000000000000000000000000000000000000000000}
+# Code upgrade only (implementation swap; storage, version, and merkle root
+# untouched). For a version upgrade / validator rotation, use
+# UpdateBridgeValidatorConfig.s.sol driven by pod's scripts/bridge-upgrade.sh.
 
-echo "Upgrading bridge..."
+echo "Upgrading bridge implementation..."
 echo "RPC:          $SOURCE_CHAIN_RPC"
 echo "Bridge proxy: $BRIDGE_PROXY_ADDRESS"
-echo "Merkle root:  $MERKLE_ROOT"
 
 forge script ./script/UpgradeBridge.s.sol:UpgradeBridge \
   --rpc-url "$SOURCE_CHAIN_RPC" \
   --private-key "$BRIDGE_ADMIN_SECRET" \
   --broadcast \
   --slow \
-  --sig "run(address,bytes32)" \
-  "$BRIDGE_PROXY_ADDRESS" "$MERKLE_ROOT"
+  --sig "run(address)" \
+  "$BRIDGE_PROXY_ADDRESS"
 
-echo "Done. Bridge upgraded."
+echo "Done. Bridge implementation upgraded."


### PR DESCRIPTION
Contract-side tooling for pod's ADR-0021 (bridge version upgrades with Merkle claims for pre-upgrade withdrawals). The Bridge contract itself is unchanged — it has supported Merkle claims all along; this adds the missing script to actually drive a version upgrade.

## Changes

- **`script/UpdateBridgeValidatorConfig.s.sol`** (new): env-driven submission of the single atomic `updateValidatorConfig` call — validator rotation + version bump + Merkle root install. Guards: `NEW_VERSION` must exceed the current version and fit `uint32` (the Merkle proof encoding reads a `uint32`); a zero root requires an explicit `ALLOW_EMPTY_MERKLE_ROOT=true` (a zero root would strand every pre-upgrade withdrawal); `version()`/`merkleRoot()` are verified after submission. Driven by pod's `scripts/bridge-upgrade.sh`, which computes `NEW_MERKLE_ROOT` itself via `node bridge-merkle-root` — the root is never passed by hand.
- **`script/UpgradeBridge.s.sol` / `script/upgrade_bridge.sh`**: now code-upgrade only. The `newMerkleRoot` parameter was dead (accepted, documented, never used) and the script printed "Validator config updated" without ever calling `updateValidatorConfig` — both removed, with a pointer to the new script for version upgrades.

## Why remove the root parameter instead of wiring it up

A proxy implementation swap preserves all storage — the version and domain separator don't change, so no certificate dies and there is nothing for a Merkle root to do. The root is only meaningful when the version bumps, and then it must land **atomically** with the bump (`updateValidatorConfig`) — installing it separately would create windows where either old certificates are dead without a Merkle fallback, or a stale root sits installed with nothing to prove. Keeping a root parameter on the code-upgrade script would preserve the trap this PR removes: an operator passing a carefully computed root, reading "Validator config updated", and walking away from a bridge that was never rotated.

## Testing

- `forge build` + full `forge test --mc BridgeTest` (86 tests) pass.
- The end-to-end flow (version bump with a pod-node-built root, certificate death, Merkle claim against this contract) is exercised by the e2e test in podnetwork/pod#1541.

Merge ordering: podnetwork/pod#1541 deliberately does not bump its pod-sdk submodule pointer; this PR merges first, then the pointer bump follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)