### PR TITLE
docs: align example deadlines to the auction interval

### DIFF
--- a/doc/api-reference/applications-precompiles/README.md
+++ b/doc/api-reference/applications-precompiles/README.md
@@ -113,7 +113,11 @@ const orderbookId = "0x000000000000000000000000000000000000000000000000000000000
 const size = ethers.parseEther("1");            // buy 1 unit
 const price = ethers.parseEther("5000");        // limit price
 const orderType = 0;                            // 0 = Limit, 1 = Market
-const deadline = BigInt(Date.now()) * 1000n;    // now in microseconds
+// Deadline: next auction tick ~10s out — must be a multiple of the market's
+// auction interval (500 ms on testnet) or validators reject the order.
+const AUCTION_INTERVAL = 500_000n;              // microseconds
+const deadline = ((BigInt(Date.now()) * 1000n + 10_000_000n + AUCTION_INTERVAL - 1n)
+  / AUCTION_INTERVAL) * AUCTION_INTERVAL;
 const ttl = 60n * 1_000_000n;                  // 60 seconds in microseconds
 
 const tx = await orderbook.submitOrder(
@@ -148,12 +152,18 @@ abi = [{"inputs": [
 
 orderbook = w3.eth.contract(address=ORDERBOOK, abi=abi)
 
+# Deadline: next auction tick ~10s out — must be a multiple of the market's
+# auction interval (500 ms on testnet) or validators reject the order.
+AUCTION_INTERVAL = 500_000  # microseconds
+now_us = int(time.time() * 1_000_000)
+deadline = (now_us + 10_000_000 + AUCTION_INTERVAL - 1) // AUCTION_INTERVAL * AUCTION_INTERVAL
+
 tx = orderbook.functions.submitOrder(
     bytes.fromhex("00" * 31 + "01"),            # orderbook id
     10**18,                                      # size: buy 1 unit
     5000 * 10**18,                               # limit price
     0,                                           # order type: 0 = Limit
-    int(time.time() * 1_000_000),                # deadline in microseconds
+    deadline,                                    # deadline in microseconds
     60 * 1_000_000,                              # ttl: 60 seconds
     False,                                       # reduce only (perp only)
     False,                                       # ioc (immediate-or-cancel)
@@ -204,9 +214,13 @@ async fn main() -> eyre::Result<()> {
         &provider,
     );
 
+    // Deadline: next auction tick ~10s out — must be a multiple of the market's
+    // auction interval (500 ms on testnet) or validators reject the order.
+    const AUCTION_INTERVAL_US: u128 = 500_000;
     let now_us = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)?
-        .as_micros() as u128;
+        .as_micros();
+    let deadline = (now_us + 10_000_000).div_ceil(AUCTION_INTERVAL_US) * AUCTION_INTERVAL_US;
 
     let one_e18 = U256::from(10).pow(U256::from(18));
 
@@ -215,7 +229,7 @@ async fn main() -> eyre::Result<()> {
         I256::from_raw(one_e18),                 // size: buy 1 unit
         U256::from(5000) * one_e18,              // limit price
         Orderbook::OrderType::Limit,             // order type
-        now_us,                                   // deadline
+        deadline,                                 // deadline (auction-tick aligned)
         60 * 1_000_000,                          // ttl: 60 seconds
         false,                                    // reduceOnly (perp only)
         false,                                    // ioc — immediate-or-cancel

--- a/doc/api-reference/applications-precompiles/orderbook.md
+++ b/doc/api-reference/applications-precompiles/orderbook.md
@@ -31,6 +31,8 @@ deadline = ceil((now + LAG) / auction_interval) * auction_interval
 
 `LAG` is the headroom you add to `now` so the intent reaches enough validators before its target batch. It is capped at **10 minutes**; aim for **at least 1 minute** under normal conditions, smaller when you want to target a specific upcoming batch.
 
+The alignment rule applies to **every deadline-bearing call** on this precompile — `deposit` and `withdraw` as much as orders, cancels, updates and triggers. All of them pass through the same validator check, so an unaligned deposit deadline is rejected just like an unaligned order deadline.
+
 See [Batch Deadline](../../protocol/orderbook.md#batch-deadline) in the protocol reference for the full discussion of `deadline` semantics and the trade-offs around `LAG`.
 {% endhint %}
 

--- a/doc/api-reference/guides/delegate-a-trading-key.md
+++ b/doc/api-reference/guides/delegate-a-trading-key.md
@@ -45,7 +45,10 @@ const abi = [
 const orderbook = new ethers.Contract(ORDERBOOK, abi, delegate);
 
 const nvdaPerpId = "0x0000000000000000000000000000000000000000000000000000000000000007"; // NVDA-USD perp
-const deadline = now + 10_000_000n; // must be <= validUntil
+// Aligned to the market's auction interval (500 ms) — see Notes below.
+const AUCTION_INTERVAL = 500_000n;
+const deadline = ((now + 10_000_000n + AUCTION_INTERVAL - 1n) / AUCTION_INTERVAL)
+  * AUCTION_INTERVAL; // must be <= validUntil
 const ttl = 60n * 1_000_000n;
 
 // 5 NVDA long at $140 limit, owned by the master
@@ -116,7 +119,10 @@ let orderbook = Orderbook::new(
 
 let nvda_perp_id = FixedBytes::left_padding_from(&[7]); // NVDA-USD perp
 let one_e18 = U256::from(10).pow(U256::from(18));
-let deadline = u128::from(now_us) + 10_000_000; // must be <= valid_until
+// Aligned to the market's auction interval (500 ms) — see Notes below.
+const AUCTION_INTERVAL_US: u128 = 500_000;
+let deadline = (u128::from(now_us) + 10_000_000).div_ceil(AUCTION_INTERVAL_US)
+    * AUCTION_INTERVAL_US; // must be <= valid_until
 let ttl = 60 * 1_000_000;
 
 // 5 NVDA long at $140 limit, owned by the master

--- a/doc/api-reference/guides/place-a-perpetual-order.md
+++ b/doc/api-reference/guides/place-a-perpetual-order.md
@@ -29,17 +29,22 @@ const orderbook = new ethers.Contract(ORDERBOOK, abi, wallet);
 // USD is Pod's native token — use the canonical native-token sentinel address
 const USD = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const nvdaPerpId = "0x0000000000000000000000000000000000000000000000000000000000000007"; // NVDA-USD perp (max 20x)
-const now = BigInt(Date.now()) * 1000n; // microseconds
+
+// Deadlines must be an exact multiple of the market's auction interval
+// (500 ms on every testnet market) or validators reject the intent.
+const AUCTION_INTERVAL = 500_000n; // microseconds
+const deadlineAfter = (lagUs: bigint): bigint =>
+  ((BigInt(Date.now()) * 1000n + lagUs + AUCTION_INTERVAL - 1n) / AUCTION_INTERVAL) * AUCTION_INTERVAL;
 
 // 1. Deposit USD margin
 const margin = ethers.parseEther("1000"); // 1,000 USD
-await (await orderbook.deposit(USD, wallet.address, margin, now + 60_000_000n)).wait();
+await (await orderbook.deposit(USD, wallet.address, margin, deadlineAfter(60_000_000n))).wait();
 
 // 2. Open a long on NVDA-USD: 5 NVDA at $140 limit
 const size = ethers.parseEther("5");          // +5 NVDA long (negative = short)
 const price = ethers.parseEther("140");       // limit price in USD
 const orderType = 0;                          // 0 = Limit
-const deadline = now + 10_000_000n;
+const deadline = deadlineAfter(10_000_000n); // include in batches within the next ~10 seconds
 const ttl = 60n * 1_000_000n;
 
 const tx = await orderbook.submitOrder(
@@ -84,21 +89,27 @@ let orderbook = Orderbook::new(
 // USD is Pod's native token — use the canonical native-token sentinel address
 let pusd: Address = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE".parse()?;
 let nvda_perp_id = FixedBytes::left_padding_from(&[7]); // NVDA-USD perp (max 20x)
+let one_e18 = U256::from(10).pow(U256::from(18));
+
+// Deadlines must be an exact multiple of the market's auction interval
+// (500 ms on every testnet market) or validators reject the intent.
+const AUCTION_INTERVAL_US: u128 = 500_000;
 let now_us = std::time::SystemTime::now()
     .duration_since(std::time::UNIX_EPOCH)?
-    .as_micros() as u128;
-let one_e18 = U256::from(10).pow(U256::from(18));
+    .as_micros();
+let deadline_after =
+    |lag_us: u128| (now_us + lag_us).div_ceil(AUCTION_INTERVAL_US) * AUCTION_INTERVAL_US;
 
 // 1. Deposit USD margin
 let margin = U256::from(1000) * one_e18;
 orderbook
-    .deposit(pusd, signer.address(), margin, now_us + 60_000_000)
+    .deposit(pusd, signer.address(), margin, deadline_after(60_000_000))
     .send().await?.watch().await?;
 
 // 2. Open a long on NVDA-USD: 5 NVDA at $140 limit
 let size = I256::from_raw(U256::from(5) * one_e18);   // +5 NVDA long
 let price = U256::from(140) * one_e18;                // limit price in USD
-let deadline = now_us + 10_000_000;
+let deadline = deadline_after(10_000_000); // include in batches within the next ~10 seconds
 let ttl = 60 * 1_000_000;
 
 let tx = orderbook

--- a/doc/api-reference/guides/place-a-spot-order.md
+++ b/doc/api-reference/guides/place-a-spot-order.md
@@ -31,17 +31,22 @@ const orderbook = new ethers.Contract(ORDERBOOK, abi, wallet);
 // USD is the native token; NVDAx is the synthetic Nvidia base
 const USD = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const orderbookId = "0x0000000000000000000000000000000000000000000000000000000000000001"; // NVDAx-USD spot
-const now = BigInt(Date.now()) * 1000n; // microseconds
+
+// Deadlines must be an exact multiple of the market's auction interval
+// (500 ms on every testnet market) or validators reject the intent.
+const AUCTION_INTERVAL = 500_000n; // microseconds
+const deadlineAfter = (lagUs: bigint): bigint =>
+  ((BigInt(Date.now()) * 1000n + lagUs + AUCTION_INTERVAL - 1n) / AUCTION_INTERVAL) * AUCTION_INTERVAL;
 
 // 1. Deposit USD (the quote token) into the orderbook
 const depositAmount = ethers.parseEther("1000");
-await (await orderbook.deposit(USD, wallet.address, depositAmount, now + 60_000_000n)).wait();
+await (await orderbook.deposit(USD, wallet.address, depositAmount, deadlineAfter(60_000_000n))).wait();
 
 // 2. Submit a buy limit order: 1 NVDAx at 200 USD
 const size = ethers.parseEther("1");         // buy 1 NVDAx (positive = buy)
 const price = ethers.parseEther("200");      // limit price in USD
 const orderType = 0;                         // 0 = Limit, 1 = Market
-const deadline = now + 10_000_000n;          // include in batches within next 10 seconds
+const deadline = deadlineAfter(10_000_000n); // include in batches within the next ~10 seconds
 const ttl = 60n * 1_000_000n;               // order lives for 60 seconds
 
 const tx = await orderbook.submitOrder(
@@ -86,21 +91,27 @@ let orderbook = Orderbook::new(
 // USD is the native token; NVDAx is the synthetic Nvidia base
 let pusd: Address = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE".parse()?;
 let orderbook_id = FixedBytes::left_padding_from(&[1]); // NVDAx-USD spot
+
+// Deadlines must be an exact multiple of the market's auction interval
+// (500 ms on every testnet market) or validators reject the intent.
+const AUCTION_INTERVAL_US: u128 = 500_000;
 let now_us = std::time::SystemTime::now()
     .duration_since(std::time::UNIX_EPOCH)?
-    .as_micros() as u128;
+    .as_micros();
+let deadline_after =
+    |lag_us: u128| (now_us + lag_us).div_ceil(AUCTION_INTERVAL_US) * AUCTION_INTERVAL_US;
 
 // 1. Deposit USD (the quote token) into the orderbook
 let one_e18 = U256::from(10).pow(U256::from(18));
 let deposit_amount = U256::from(1000) * one_e18;
 orderbook
-    .deposit(pusd, signer.address(), deposit_amount, now_us + 60_000_000)
+    .deposit(pusd, signer.address(), deposit_amount, deadline_after(60_000_000))
     .send().await?.watch().await?;
 
 // 2. Submit a buy limit order: 1 NVDAx at 200 USD
 let size = I256::from_raw(one_e18); // buy 1 NVDAx
 let price = U256::from(200) * one_e18; // limit price in USD
-let deadline = now_us + 10_000_000; // include in batches within next 10 seconds
+let deadline = deadline_after(10_000_000); // include in batches within the next ~10 seconds
 let ttl = 60 * 1_000_000; // order lives for 60 seconds
 
 let tx = orderbook

--- a/doc/api-reference/guides/submit-a-batch-order.md
+++ b/doc/api-reference/guides/submit-a-batch-order.md
@@ -30,10 +30,15 @@ const abi = [
 const orderbook = new ethers.Contract(ORDERBOOK, abi, wallet);
 
 const nvdaPerpId = "0x0000000000000000000000000000000000000000000000000000000000000007"; // NVDA-USD perp
-const now = BigInt(Date.now()) * 1000n; // microseconds
+
+// Deadlines must be an exact multiple of the market's auction interval
+// (500 ms on every testnet market) or validators reject the intent.
+const AUCTION_INTERVAL = 500_000n; // microseconds
+const deadlineAfter = (lagUs: bigint): bigint =>
+  ((BigInt(Date.now()) * 1000n + lagUs + AUCTION_INTERVAL - 1n) / AUCTION_INTERVAL) * AUCTION_INTERVAL;
 
 // One shared deadline for the whole envelope — required by submitBatch.
-const deadline = now + 10_000_000n;
+const deadline = deadlineAfter(10_000_000n);
 const ttl = 60n * 1_000_000n;
 const size = ethers.parseEther("5"); // +5 NVDA long
 
@@ -99,13 +104,17 @@ let orderbook = Orderbook::new(
 );
 
 let nvda_perp_id = FixedBytes::left_padding_from(&[7]); // NVDA-USD perp
-let now_us = std::time::SystemTime::now()
-    .duration_since(std::time::UNIX_EPOCH)?
-    .as_micros() as u128;
 let one_e18 = U256::from(10).pow(U256::from(18));
 
+// Deadlines must be an exact multiple of the market's auction interval
+// (500 ms on every testnet market) or validators reject the intent.
+const AUCTION_INTERVAL_US: u128 = 500_000;
+let now_us = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)?
+    .as_micros();
+
 // One shared deadline for the whole envelope — required by submitBatch.
-let deadline = now_us + 10_000_000;
+let deadline = (now_us + 10_000_000).div_ceil(AUCTION_INTERVAL_US) * AUCTION_INTERVAL_US;
 let ttl = 60 * 1_000_000;
 let size = I256::from_raw(U256::from(5) * one_e18); // +5 NVDA long
 


### PR DESCRIPTION
## Summary

Fixes audit finding **HIGH-9**: every runnable example in the trading guides and the precompiles README computed `deadline` as raw wall-clock microseconds plus fixed headroom. Validators reject any intent deadline that is not an exact multiple of the auction interval (`validate_intent_deadline`, `node/src/clob/mod.rs`), so all of these snippets failed on first run with `"CLOB validation failed: Deadline is not aligned to auction interval"`.

Three aggravations found while fixing:

- **Deposit deadlines break too.** `validate_intent_deadline` is shared by all intents, including `deposit`/`withdraw` — so step 1 of each guide failed before an order was even attempted. The orderbook reference now states the alignment rule covers every deadline-bearing call.
- **The precompiles README snippets had zero headroom** (`deadline = now`), so their deadlines were also already in the past by validation time; they now use ~10s of aligned headroom like the guides.
- **The key-delegation guide (added after the audit) had the same bug** — its wrapped inner intent goes through the same check, and its own Notes section already stated the alignment rule its snippets violated.

All snippets now compute `deadline = ceil((now + LAG) / auction_interval) * auction_interval`, matching the rule already documented in the orderbook precompile reference (which the guides link to). The `optimistic-auction.md` deadline is intentionally untouched — the auctions precompile is a different validation path (tracked separately as audit finding HIGH-11).

## Changes

- `doc/api-reference/guides/place-a-spot-order.md` — TS + Rust tabs: aligned `deadlineAfter`/`deadline_after` helper, used for deposit + order deadlines
- `doc/api-reference/guides/place-a-perpetual-order.md` — same
- `doc/api-reference/guides/submit-a-batch-order.md` — TS + Rust tabs: aligned shared envelope deadline
- `doc/api-reference/guides/delegate-a-trading-key.md` — TS + Rust tabs: aligned inner-intent deadline
- `doc/api-reference/applications-precompiles/README.md` — JS, Python, Rust tabs: aligned deadline with ~10s headroom
- `doc/api-reference/applications-precompiles/orderbook.md` — note that alignment applies to deposits/withdrawals/cancels/updates/triggers as well as orders

## Verification

The ceil-alignment arithmetic was executed for the Python (interpreter) and Rust (`rustc`, exact snippet lines) versions: results are exact multiples of 500 000 µs, ~10s in the future, and already-aligned inputs are not bumped a tick. The JS/TS expression is operand-for-operand the same all-positive integer math (BigInt division truncates like Python `//`).

Docs-only; no node or SDK code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)