### PR TITLE
fix(script): deploy_deposit_waiting_list.sh arity mismatch with DeployDepositWaitingList.run

### DIFF
--- a/protocol/script/deploy_deposit_waiting_list.sh
+++ b/protocol/script/deploy_deposit_waiting_list.sh
@@ -28,8 +28,8 @@ DEPLOY_OUTPUT=$(forge script ./script/DeployDepositWaitingList.s.sol:DeployDepos
   --private-key "$RELAYER_SECRET" \
   --broadcast \
   --slow \
-  --sig "run(address,address)" \
-  "$BRIDGE_ADDRESS" "$RELAYER_ADDRESS")
+  --sig "run(address,address,address)" \
+  "$BRIDGE_ADDRESS" "$BRIDGE_ADMIN_ADDRESS" "$RELAYER_ADDRESS")
 
 echo "$DEPLOY_OUTPUT"
 


### PR DESCRIPTION
DeployDepositWaitingList.s.sol defines run(address bridge, address admin, address relayer), but the wrapper invoked it with --sig run(address,address) and only bridge+relayer, so the deploy step fails on every invocation. Pass the already-derived BRIDGE_ADMIN_ADDRESS as the admin argument and fix the signature. Found during the Sepolia bridge upgrade campaign (podnetwork/pod#1584). Verified with bash -n and against the forge script signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)