### PR TITLE
docs: remove SolutionExecuted event from orderbook precompile reference

### DIFF
--- a/doc/api-reference/applications-precompiles/orderbook.md
+++ b/doc/api-reference/applications-precompiles/orderbook.md
@@ -72,16 +72,6 @@ contract Orderbook {
     //        `position` in RPC responses.)
     enum TriggerGrouping { None, Asset }
 
-    // --- Events ---
-
-    event SolutionExecuted(
-        bytes32 indexed orderbookId,
-        uint128 deadline,
-        uint256 clearingPrice,
-        uint256 totalVolume,
-        uint256 newOrdersCount
-    );
-
     // --- Order Management ---
 
     /**


### PR DESCRIPTION
Removes the `SolutionExecuted` event from the orderbook precompile ABI reference.

The CLOB precompile no longer emits this event — it is removed node-side in podnetwork/pod#1589. It was the sole log emitter for the CLOB address (one log per orderbook per tick, including idle markets) and the source of the oversized `logs` tables behind recent `eth_getLogs` OOMs.

`SolutionExecuted` was the only entry under the `// --- Events ---` section, so the section is dropped entirely; no other part of the ABI changes.

The WebSocket `pod_*` push mechanism referenced in `ts-sdk-design.md` (fanned out from the internal per-tick solution result) is a different, still-present mechanism and is intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
