### PR TITLE
fix(ts-sdk): default market orders to immediate-or-cancel

### DIFF
--- a/ts-sdk/src/write/index.ts
+++ b/ts-sdk/src/write/index.ts
@@ -50,6 +50,12 @@ export interface SubmitOrderParams {
    */
   auctionIntervalUs?: number;
   reduceOnly?: boolean;
+  /**
+   * Immediate-or-cancel. Defaults to `true` for a market order and `false` for
+   * a limit order: a market order carries no resting price of its own, so the
+   * CLOB rejects one that could outlive its batch ("market orders must be
+   * immediate-or-cancel"). Only set this explicitly to make a *limit* order IOC.
+   */
   ioc?: boolean;
   deadline?: number; // ms; default far future
   ttl?: number; // ms; default far future
@@ -98,7 +104,10 @@ export function buildSubmitOrder(p: SubmitOrderParams): PodTxRequest {
       deadline,
       ttl,
       p.reduceOnly ?? false,
-      p.ioc ?? false,
+      // A market order must not outlive its batch — the CLOB rejects a non-IOC
+      // market order outright (`validate_order_shape`, trading/src/book.rs), so
+      // default it on rather than making every caller remember.
+      p.ioc ?? p.orderType === "market",
     ],
   }) as Hex;
   return { to: CLOB_ADDRESS, data, value: 0n, type: "eip1559", maxPriorityFeePerGas: 0n, gas: 1_000_000n };


### PR DESCRIPTION
The CLOB rejects any market order that isn't immediate-or-cancel: a market order carries no resting price of its own, so it must not outlive its batch. `validate_order_shape` (`trading/src/book.rs`) is the guard:

```rust
if order.order_type == OrderType::Market && !order.ioc {
    return Err(Reject::Other("market orders must be immediate-or-cancel".into()));
}
```

`buildSubmitOrder` encoded `p.ioc ?? false`, and no caller sets `ioc` — so **every market order this SDK built was refused before it could reach the book**, and so was every `buildClosePosition` (which builds a market order), leaving positions uncloseable. Market is the default order type in the trading frontend, so its default trade path never worked.

This defaults `ioc` to `orderType === "market"`. An explicit value still wins in both directions, so a caller can still make a limit order IOC.

## Verification

Reproduced and confirmed against staging by submitting the frontend's exact order from a throwaway unfunded key (a rejected tx cannot mutate state):

- market order, `ioc=false` → `CLOB validation failed: Perp order pre-validation failed: market orders must be immediate-or-cancel`
- market order, `ioc=true` → `insufficient balance: required=…, available=0`, i.e. it clears CLOB validation and fails only on the empty account, exactly like a limit order

Decoding the calldata from the built output covers the matrix: market defaults to IOC, limit stays non-IOC, explicit `ioc` is honoured in both directions, and `buildClosePosition` comes out IOC.

`npm run typecheck` passes. Note `ts-sdk` has no test runner (only `build`/`typecheck`), so there's no unit test here — adding a harness felt out of scope for a one-line fix, but it's the obvious follow-up if you want this locked down.

Triggers were checked and are unaffected: `TriggerOrder::synthetic_order` hardcodes `order_type: OrderType::Limit`, so a fired trigger never trips the guard whatever its `ioc`; its `limitPrice` also defaults to `triggerPrice`, so it can't emit a zero-price order either.

Needs a `pod` submodule pointer bump once merged.