### PR TITLE
docs(orderbook): document the solution state commitment

### DIFF
--- a/doc/protocol/orderbook.md
+++ b/doc/protocol/orderbook.md
@@ -62,6 +62,24 @@ The solver is the service responsible for settling a batch. It can be a rotating
 
 The solver does not get any additional advantage. It cannot censor transactions or include transactions that were not submitted in time. It has some flexibility on whether to include out-of-time transactions - orders submitted after the batch timestamp, or orders that received some attestations but fewer than the required n − f. These orders always lose, because they cannot claim funds even if they get matched.
 
+### Solution state commitment
+
+A solution is built against the state the previous batch left behind. Every settlement carries `previousStateHash` - the solver's fingerprint of that state - and each validator compares it against a fingerprint it computes from its own state before attesting. A solution whose claim disagrees is rejected, so a node whose trading state has drifted from the solver's stops attesting rather than settling on state nobody else has.
+
+A single settlement can cover several consecutive batches when the solver is catching up. They are all built from the same starting state, so one `previousStateHash` covers the whole call.
+
+The fingerprint is a CRC-32 digest - fast, since every node recomputes it once per batch - right-aligned in the `bytes32`. It covers the deadline of the batch that produced it, which binds the fingerprint to that batch, followed by every orderbook in ascending `orderbookId` order. Each orderbook contributes:
+
+* its last clearing price
+* its last mark price and last oracle price - spot markets have neither
+* its best ten resting orders per side, best first, as (price, remaining size) pairs - fewer if the side is thinner
+
+A price the market does not have, and an empty book side, fold in as a `-` marker rather than as zero, so "never traded" stays distinguishable from "traded at zero".
+
+A market with no price of any kind and an empty book contributes nothing at all. Market configuration reaches nodes one at a time, so a node that already knows about a new - and therefore still untraded - market has to agree with one that does not.
+
+`bytes32(0)` means "no reference point yet": a chain that has not settled a batch, or a node restarted from state written before the commitment existed. When either side is zero the comparison is skipped, and both sides recover a real value from the next settled batch.
+
 ### References
 
 * E. Budish, P. Cramton, J. Shim. _The High-Frequency Trading Arms Race: Frequent Batch Auctions as a Market Design Response._ Quarterly Journal of Economics, 2015.


### PR DESCRIPTION
## Why

Settlements now carry `previousStateHash` — the solver's fingerprint of the state the previous batch left behind. Validators compare it against a fingerprint they compute from their own state and reject a solution whose claim disagrees, so a node whose trading state has drifted stops attesting rather than settling on state nobody else has.

An external solver has to reproduce that digest byte for byte, so the composition belongs in the protocol reference rather than only in the node.

## What

One new subsection under **Matching → Solver** in `doc/protocol/orderbook.md`:

- what the commitment is and what rejection means
- one hash covers a whole multi-batch catch-up settlement, since every batch in it is built from the same starting state
- the digest: CRC-32, right-aligned in the `bytes32`, over the batch deadline (which binds the fingerprint to that batch) then every orderbook in ascending `orderbookId` order — clearing price, mark price, oracle price, best ten resting orders per side
- absence is marked with `-` rather than zero-filled, so "never traded" stays distinguishable from "traded at zero"
- a market with no price and an empty book contributes nothing, so nodes mid-config-rollout still agree
- `bytes32(0)` means "no reference point yet" and the comparison is skipped

Implementation: podnetwork/pod#1599.

## Notes for the reviewer

- **Merge timing.** The text describes the check as active. On the node side it is gated behind a configured activation deadline so the network can flip at one batch, and that gate is deliberately not described here (it is an operational detail, not protocol). Merging this before the network enables it would document behaviour that is not live yet — worth landing alongside the activation.
- **No ABI listing.** `api-reference/applications-precompiles/orderbook.md` no longer carries the solver calldata at all — the solution structs were dropped when that page was restructured for traders. I did not re-add them, so `previousStateHash` does not appear in an ABI block anywhere. Say the word if the reference should carry the solver surface again and I will add it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
