### PR TITLE
build(ts-sdk): publish @pod-network/trade-sdk to npm on a ts-sdk-scoped tag

### DIFF
--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Public access comes from publishConfig.access in package.json rather than
+      # an --access flag, so it holds for every publish path, not just this one.
       - name: Publish
-        run: npm publish --provenance --access public --tag "${{ steps.version.outputs.npm_tag }}"
+        run: npm publish --provenance --tag "${{ steps.version.outputs.npm_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -1,0 +1,69 @@
+name: Publish ts-sdk
+
+# A ts-sdk-scoped tag, so TypeScript releases stay decoupled from the shared `v*`
+# tag that release.yml uses to zip every SDK into a GitHub Release: a TypeScript
+# patch should not force a rust-sdk release. `ts-sdk-v*` does not match `v*`, so
+# the two workflows never fire for the same tag.
+on:
+  push:
+    tags:
+      - "ts-sdk-v*"
+
+permissions:
+  contents: read
+  id-token: write # required for `npm publish --provenance`
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ts-sdk
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: ts-sdk/package-lock.json
+
+      - name: Resolve version and dist-tag
+        id: version
+        run: |
+          # The tag triggers the release, but package.json is the source of
+          # truth. Without this check, tagging ts-sdk-v0.1.0 against a manifest
+          # still reading 0.0.0 would publish a mislabelled version — and an npm
+          # version can never be reused, so that mistake is permanent.
+          tag_version="${GITHUB_REF_NAME#ts-sdk-v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::tag ${GITHUB_REF_NAME} implies ${tag_version}, but package.json says ${pkg_version}"
+            exit 1
+          fi
+          # npm applies the `latest` dist-tag even to a semver prerelease, which
+          # would make a release candidate the default install for every
+          # consumer. Route hyphenated versions to `rc` instead.
+          case "$pkg_version" in
+            *-*) npm_tag=rc ;;
+            *) npm_tag=latest ;;
+          esac
+          echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
+          echo "Publishing $pkg_version under dist-tag $npm_tag"
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # `ts-sdk/dist` is gitignored, so it does not exist in a fresh checkout and
+      # the package would publish empty without this.
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --provenance --access public --tag "${{ steps.version.outputs.npm_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,34 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+  # Until this job existed, no CI anywhere touched the TypeScript — a broken
+  # ts-sdk only surfaced when a downstream image build failed. It is also the
+  # gate reused by publish-ts-sdk.yml, so a release cannot ship code that does
+  # not compile. ts-sdk has no test runner; typecheck + build is the gate.
+  ts-sdk:
+    name: ts-sdk
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ts-sdk
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ts-sdk/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
   contracts:
     name: examples-solidity
     runs-on: ubuntu-latest

--- a/ts-sdk/README.md
+++ b/ts-sdk/README.md
@@ -74,3 +74,40 @@ All monetary values are `bigint` (1e18-scaled; use `formatAmount`/`toNumber`/
 ```bash
 npm install && npm run build      # build the package to dist/
 ```
+
+## Working on the SDK and a consumer together
+
+The consumer's committed dependency is always the published version. To iterate
+locally, link this package into it instead of editing that dependency:
+
+```bash
+cd ts-sdk && npm run build && npm link
+cd ../../frontend && npm link @pod-network/trade-sdk
+# undo
+npm unlink @pod-network/trade-sdk && npm ci
+```
+
+`dist/` is what consumers import, so rebuild after each change. Nothing is
+committed on either side, so a local path can never leak into a release.
+
+## Releasing
+
+Publishing is driven by a **`ts-sdk-v*`** tag, which is deliberately distinct
+from the repo-wide `v*` tag that `release.yml` uses to zip every SDK into a
+GitHub Release — so a TypeScript release doesn't drag `rust-sdk` along:
+
+```bash
+# 1. bump the version in package.json, commit it
+# 2. tag it — the tag must match package.json or the job fails
+git tag ts-sdk-v0.1.0 && git push origin ts-sdk-v0.1.0
+```
+
+`publish-ts-sdk.yml` then typechecks, builds and publishes to npm with
+provenance. Two things worth knowing:
+
+- A version containing a hyphen (`0.2.0-rc.0`) publishes under the **`rc`**
+  dist-tag, leaving `latest` alone — so prereleases never become the default
+  install. Use one to rehearse a release; npm versions can never be reused.
+- `dist/` is gitignored and built during the release, and `prepublishOnly`
+  rebuilds it on any manual `npm publish` too, so a stale or empty `dist/`
+  can't ship.

--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-network/trade-sdk",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Read/stream TypeScript SDK for the pod trading indexer: cacheable REST seeds + one multiplexed WebSocket, kept in memory. Framework-agnostic.",
   "type": "module",
   "sideEffects": false,
@@ -15,9 +15,20 @@
     }
   },
   "files": ["dist", "src"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/podnetwork/pod-sdk.git",
+    "directory": "ts-sdk"
+  },
+  "homepage": "https://github.com/podnetwork/pod-sdk/tree/main/ts-sdk#readme",
+  "bugs": "https://github.com/podnetwork/pod-sdk/issues",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "viem": "^2.21.0"


### PR DESCRIPTION
`ts-sdk` has never been published, so consumers link it from a sibling checkout with `file:../pod-sdk/ts-sdk`. That carries no version, and a consumer checking this repo out with no `ref` compiles against whatever the default branch happens to be — builds aren't reproducible, and an SDK change reaches users with nothing in the consumer's history recording which SDK shipped.

That isn't hypothetical. `buildSubmitOrder` defaulted `ioc` to `false` while the CLOB rejects any market order that isn't immediate-or-cancel, so every market order the trading frontend built was refused and positions couldn't be closed. The fix reached the deployed app with no frontend commit at all — a regression would have travelled exactly as silently.

## Release flow

Publishing is driven by a `ts-sdk-v*` tag. That's deliberately distinct from the repo-wide `v*` tag `release.yml` already uses to zip every SDK into a GitHub Release, so a TypeScript patch doesn't drag `rust-sdk` along, and the two globs never fire for the same tag.

The job resolves the version, then runs `npm ci` → `typecheck` → `build` → `npm publish --provenance`, authenticating with the `NPM_TOKEN` secret.

Two guards, each covering a mistake that can't be undone:

- **Tag vs manifest.** The tag triggers the release but `package.json` is the source of truth, so tagging `ts-sdk-v0.1.0` against a manifest reading `0.0.0` fails instead of publishing a mislabelled version. An npm version can never be reused.
- **Prerelease dist-tag.** `npm publish` applies `latest` even to a semver prerelease, which would make a release candidate the default install for every consumer. Hyphenated versions go to `rc` instead, so a rehearsal is harmless.

## Manifest

`version` `0.0.0` → `0.1.0`, plus `publishConfig.access: public` (scoped packages default to restricted, so the first publish would otherwise fail or land private), `repository`/`homepage`/`bugs`, and `prepublishOnly` so a manual publish can't ship a stale `dist/` — `dist` is gitignored and absent from a fresh checkout.

Access is set only via `publishConfig`, not an `--access` flag, so it holds for every publish path rather than just this workflow.

## Closing a CI gap

Adds a `ts-sdk` job to `test.yml`. Until now no CI anywhere touched the TypeScript — `test.yml`, `lint.yml` and `format.yml` are all cargo and Foundry — so a broken SDK only surfaced when a downstream image build failed. The same job gates the release, so a publish can't ship code that doesn't compile.

`typecheck` and `build` both run and are not redundant: `tsconfig.build.json` excludes `**/*.test.ts` and `examples`, so `typecheck` covers a strict superset.

## Verified

`npm ci`, `npm run typecheck` and `npm run build` all pass. `npm publish --dry-run` resolves to `@pod-network/trade-sdk@0.1.0`, 102 files, 111.3 kB, reporting public access without the `--access` flag. The `npm pack` tarball contains all four `exports` targets — `dist/index.js`, `dist/index.d.ts`, `dist/write/index.js`, `dist/write/index.d.ts` — so the package imports rather than merely installing, and the packaged `dist/write/index.js` carries the immediate-or-cancel fix.

One redundancy is kept knowingly: `prepublishOnly` and the explicit Build step mean `tsc` runs twice. Removing the explicit step would make a correct publish depend on `prepublishOnly` firing, and if that were ever wrong the package would publish empty to a version npm will never let us reuse. A few seconds of compile is cheap insurance against a one-way failure.

## After merging

Nothing is published by this PR. Merge first so a tag on `main` picks up the workflow, then rehearse with `0.1.0-rc.0` (manifest + `ts-sdk-v0.1.0-rc.0`) and confirm it lands under `rc` with `latest` untouched, before tagging `ts-sdk-v0.1.0`.

The frontend switchover is a separate follow-up, since it can't depend on `^0.1.0` until that version exists. It keeps its commit pin until then, and that pin plus the whole second checkout step get deleted in the same change that adopts the npm dependency.