### PR TITLE
build(ts-sdk): publish via trusted publisher, retiring NPM_TOKEN

### DIFF
--- a/.github/workflows/publish-ts-sdk.yml
+++ b/.github/workflows/publish-ts-sdk.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # required for `npm publish --provenance`
+  id-token: write # the OIDC token npm exchanges for publish rights (and provenance)
 
 jobs:
   publish:
@@ -22,12 +22,21 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Trusted publishing needs Node >= 22.14.0 and npm >= 11.5.1.
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: ts-sdk/package-lock.json
+
+      # No bundled npm meets the 11.5.1 floor — Node 22 ships 10.9.x and Node 24
+      # shipped 11.3 — so upgrade explicitly rather than relying on the runner.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Show toolchain
+        run: node --version && npm --version
 
       - name: Resolve version and dist-tag
         id: version
@@ -63,9 +72,12 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Authenticated by OIDC via a trusted publisher on npm, so there is no
+      # token here and no long-lived credential in repo secrets. `id-token: write`
+      # above is what makes that possible. Provenance is generated automatically
+      # under trusted publishing, so --provenance is not passed.
+      #
       # Public access comes from publishConfig.access in package.json rather than
       # an --access flag, so it holds for every publish path, not just this one.
       - name: Publish
-        run: npm publish --provenance --tag "${{ steps.version.outputs.npm_tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --tag "${{ steps.version.outputs.npm_tag }}"


### PR DESCRIPTION
Switches the npm publish from a long-lived `NPM_TOKEN` to OIDC against the trusted publisher now configured on npm. The workflow carries no credential at all — `id-token: write` is what makes the exchange possible.

Provenance is generated automatically under trusted publishing, so `--provenance` is dropped; the attestation still gets signed and logged.

## Why the Node/npm bump is part of this

Trusted publishing requires **Node >= 22.14.0 and npm >= 11.5.1**. The old job pinned Node 20, which ships npm ~10.8, so OIDC publishing could not work on it.

The explicit `npm install -g npm@latest` is necessary rather than defensive: no bundled npm clears the floor. Node 22.14 ships npm 10.9.x, and even Node 24 shipped 11.3. Relying on the runner's bundled version would break the moment it drifted.

## Verified before opening this

Published `0.1.1-rc.0` from this exact workflow with no token present:

- authenticated purely by OIDC on Node 24.18.0 with npm upgraded past the floor
- npm signed and logged provenance **without** the flag ([sigstore logIndex 2289122227](https://search.sigstore.dev/?logIndex=2289122227)), attached as a SLSA provenance v1 attestation
- landed under the `rc` dist-tag with `latest` left at `0.1.0`, confirming the dist-tag routing still holds

The rehearsal lived on a throwaway commit reachable only by the `ts-sdk-v0.1.1-rc.0` tag, so `main` never carried the version bump — this PR is the workflow change alone, and the manifest stays at `0.1.0`.

## After merging

**Delete the `NPM_TOKEN` secret.** Nothing references it once this lands, and retiring that standing credential is the point of the change.