### PR TITLE
docs(json-rpc): document server-initiated subscription closes

### DIFF
--- a/doc/api-reference/json-rpc-errors.md
+++ b/doc/api-reference/json-rpc-errors.md
@@ -144,7 +144,7 @@ The subscription is over once this arrives; nothing further is sent for it. The 
 | `data` field   | Type    | Description                                                                                                                                                        |
 | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `resumable`    | boolean | Whether resubscribing recovers the stream. `false` only for `-32023`.                                                                                              |
-| `resume_since` | number  | Solution time (µs) of the last tick fully delivered on this subscription — pass it back as `since`. Absent if nothing was delivered; then reuse your original `since`. |
+| `resume_since` | number  | Solution time (µs) of the newest tick this subscription is square on — every update it owed you was delivered (a tick that matched none of your filters owed nothing, so it counts). Pass it back as `since`. Absent if it is square on nothing yet; then reuse your original `since`. |
 | `missed`       | number  | `-32020` only: how many ticks the broadcast dropped.                                                                                                               |
 
 `resume_since` names a whole tick, because `since` selects whole ticks. So if the subscription closed midway through one, resuming redelivers that tick in full and you may see a few deltas twice. That is deliberate — a repeated delta is something a client can dedupe, whereas one that was never sent is unrecoverable — and it does not apply to channels that can resume inside a tick.

--- a/doc/api-reference/json-rpc-errors.md
+++ b/doc/api-reference/json-rpc-errors.md
@@ -147,7 +147,7 @@ The subscription is over once this arrives; nothing further is sent for it. The 
 | `resume_since` | number  | Solution time (µs) of the last tick fully delivered on this subscription — pass it back as `since`. Absent if nothing was delivered; then reuse your original `since`. |
 | `missed`       | number  | `-32010` only: how many ticks the broadcast dropped.                                                                                                               |
 
-Resuming from `resume_since` may redeliver the tick that was in flight when the subscription closed. That is deliberate: a repeated delta is something a client can dedupe, whereas one that was never sent is unrecoverable.
+`resume_since` names a whole tick, because `since` selects whole ticks. So if the subscription closed midway through one, resuming redelivers that tick in full and you may see a few deltas twice. That is deliberate — a repeated delta is something a client can dedupe, whereas one that was never sent is unrecoverable — and it does not apply to channels that can resume inside a tick.
 
 A close is the **only** signal that a delta stream lost data — the stream itself never has holes. Treat the absence of updates as an idle market only while the subscription is open.
 

--- a/doc/api-reference/json-rpc-errors.md
+++ b/doc/api-reference/json-rpc-errors.md
@@ -32,7 +32,7 @@ Every error is returned as a JSON-RPC 2.0 error object:
 | `-32000` | `transaction validation failed` | A protocol-level validation check failed (nonce, balance, chain ID, gas price, …).      |
 | `-32003` | `Transaction rejected: …`     | A quorum of validators rejected the transaction.                                          |
 | `999`    | `Account locked`              | The account is locked pending recovery. `data` carries the recovery target.              |
-| `-32010` … `-32013` | (see below)        | A websocket subscription was closed by the server. Delivered as a notification, not a response — see [Subscription close notifications](#subscription-close-notifications). |
+| `-32020` … `-32023` | (see below)        | A websocket subscription was closed by the server. Delivered as a notification, not a response — see [Subscription close notifications](#subscription-close-notifications). |
 
 ### `3` — execution reverted
 
@@ -124,7 +124,7 @@ The codes above answer a request. A websocket subscription created with [`eth_su
   "params": {
     "subscription": "0x9c1f…",
     "error": {
-      "code": -32010,
+      "code": -32020,
       "message": "subscription lagged behind the tick broadcast",
       "data": { "resumable": true, "missed": 42, "resume_since": 1718900000000000 }
     }
@@ -136,16 +136,16 @@ The subscription is over once this arrives; nothing further is sent for it. The 
 
 | Code     | Message                                             | What happened, and what to do                                                                                                                     |
 | -------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-32010` | `subscription lagged behind the tick broadcast`      | The server dropped ticks before this subscriber read them, rather than serve a stream with a gap in it. Resubscribe with `since` = `resume_since`. |
-| `-32011` | `node is shutting down`                              | The node is going away. Reconnect (to another node, if you have one) and resubscribe with `since` = `resume_since`.                               |
-| `-32012` | `subscriber did not accept a notification in time`   | The connection would not take a notification within the server's send timeout. Resubscribe with `since` = `resume_since` once you can keep up.     |
-| `-32013` | `failed to serialize a subscription notification`    | A server-side bug. **Do not** retry in a loop — an immediate resubscribe will likely reproduce it. Please report it.                              |
+| `-32020` | `subscription lagged behind the tick broadcast`      | The server dropped ticks before this subscriber read them, rather than serve a stream with a gap in it. Resubscribe with `since` = `resume_since`. |
+| `-32021` | `node is shutting down`                              | The node is going away. Reconnect (to another node, if you have one) and resubscribe with `since` = `resume_since`.                               |
+| `-32022` | `subscriber did not accept a notification in time`   | The connection would not take a notification within the server's send timeout. Resubscribe with `since` = `resume_since` once you can keep up.     |
+| `-32023` | `failed to serialize a subscription notification`    | A server-side bug. **Do not** retry in a loop — an immediate resubscribe will likely reproduce it. Please report it.                              |
 
 | `data` field   | Type    | Description                                                                                                                                                        |
 | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `resumable`    | boolean | Whether resubscribing recovers the stream. `false` only for `-32013`.                                                                                              |
+| `resumable`    | boolean | Whether resubscribing recovers the stream. `false` only for `-32023`.                                                                                              |
 | `resume_since` | number  | Solution time (µs) of the last tick fully delivered on this subscription — pass it back as `since`. Absent if nothing was delivered; then reuse your original `since`. |
-| `missed`       | number  | `-32010` only: how many ticks the broadcast dropped.                                                                                                               |
+| `missed`       | number  | `-32020` only: how many ticks the broadcast dropped.                                                                                                               |
 
 `resume_since` names a whole tick, because `since` selects whole ticks. So if the subscription closed midway through one, resuming redelivers that tick in full and you may see a few deltas twice. That is deliberate — a repeated delta is something a client can dedupe, whereas one that was never sent is unrecoverable — and it does not apply to channels that can resume inside a tick.
 

--- a/doc/api-reference/json-rpc-errors.md
+++ b/doc/api-reference/json-rpc-errors.md
@@ -151,7 +151,13 @@ The subscription is over once this arrives; nothing further is sent for it. The 
 
 A close is the **only** signal that a delta stream lost data — the stream itself never has holes. Treat the absence of updates as an idle market only while the subscription is open.
 
-> **Note for `alloy` (Rust) users.** `alloy`'s pubsub transport rejects a subscription notification that carries `error`, and treats the failure as a connection error: it tears the websocket down and reconnects rather than surfacing the reason. You will observe the close as a reconnect, not as a payload. To read the reason, use a raw websocket client. `viem`/`ethers` and the pod TypeScript SDK deliver it to the subscription's error handler as shown above.
+> **Client support.** Not every websocket client surfaces this frame, so check yours before relying on the reason being readable.
+>
+> - **`alloy` (Rust)** rejects a subscription notification carrying `error` and treats it as a connection error: it tears the websocket down and reconnects rather than surfacing the payload. You observe the close as a reconnect.
+> - **`jsonrpsee` (Rust)** removes the subscription and discards the payload, so the stream ends with no reason attached.
+> - **The pod TypeScript SDK** does not read `params.error` yet, so a close currently arrives as an update with an empty payload and the subscription is not dropped. Until that lands, treat a payload-less update as a possible close.
+>
+> To act on the reason with any of these, read the raw websocket frame. The subscription is over regardless of whether your client reports it.
 
 ## Transaction validation messages
 

--- a/doc/api-reference/json-rpc-errors.md
+++ b/doc/api-reference/json-rpc-errors.md
@@ -32,6 +32,7 @@ Every error is returned as a JSON-RPC 2.0 error object:
 | `-32000` | `transaction validation failed` | A protocol-level validation check failed (nonce, balance, chain ID, gas price, …).      |
 | `-32003` | `Transaction rejected: …`     | A quorum of validators rejected the transaction.                                          |
 | `999`    | `Account locked`              | The account is locked pending recovery. `data` carries the recovery target.              |
+| `-32010` … `-32013` | (see below)        | A websocket subscription was closed by the server. Delivered as a notification, not a response — see [Subscription close notifications](#subscription-close-notifications). |
 
 ### `3` — execution reverted
 
@@ -111,6 +112,46 @@ Returned when you submit a transaction for an account that is locked due to a pe
 | ----------------------- | ------ | ---------------------------------------------------- |
 | `recovery_target`       | hash   | Transaction hash of the recovery target.             |
 | `recovery_target_nonce` | number | Nonce of the recovery target.                        |
+
+## Subscription close notifications
+
+The codes above answer a request. A websocket subscription created with [`eth_subscribe`](json-rpc/openapi.yaml) can also be ended by the *server*, and that arrives as a notification rather than a response: same `eth_subscription` method as a normal update, but carrying `error` in place of `result`.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "eth_subscription",
+  "params": {
+    "subscription": "0x9c1f…",
+    "error": {
+      "code": -32010,
+      "message": "subscription lagged behind the tick broadcast",
+      "data": { "resumable": true, "missed": 42, "resume_since": 1718900000000000 }
+    }
+  }
+}
+```
+
+The subscription is over once this arrives; nothing further is sent for it. The connection itself stays open, so any other subscription on it keeps working.
+
+| Code     | Message                                             | What happened, and what to do                                                                                                                     |
+| -------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-32010` | `subscription lagged behind the tick broadcast`      | The server dropped ticks before this subscriber read them, rather than serve a stream with a gap in it. Resubscribe with `since` = `resume_since`. |
+| `-32011` | `node is shutting down`                              | The node is going away. Reconnect (to another node, if you have one) and resubscribe with `since` = `resume_since`.                               |
+| `-32012` | `subscriber did not accept a notification in time`   | The connection would not take a notification within the server's send timeout. Resubscribe with `since` = `resume_since` once you can keep up.     |
+| `-32013` | `failed to serialize a subscription notification`    | A server-side bug. **Do not** retry in a loop — an immediate resubscribe will likely reproduce it. Please report it.                              |
+
+| `data` field   | Type    | Description                                                                                                                                                        |
+| -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `resumable`    | boolean | Whether resubscribing recovers the stream. `false` only for `-32013`.                                                                                              |
+| `resume_since` | number  | Solution time (µs) of the last tick fully delivered on this subscription — pass it back as `since`. Absent if nothing was delivered; then reuse your original `since`. |
+| `missed`       | number  | `-32010` only: how many ticks the broadcast dropped.                                                                                                               |
+
+Resuming from `resume_since` may redeliver the tick that was in flight when the subscription closed. That is deliberate: a repeated delta is something a client can dedupe, whereas one that was never sent is unrecoverable.
+
+A close is the **only** signal that a delta stream lost data — the stream itself never has holes. Treat the absence of updates as an idle market only while the subscription is open.
+
+> **Note for `alloy` (Rust) users.** `alloy`'s pubsub transport rejects a subscription notification that carries `error`, and treats the failure as a connection error: it tears the websocket down and reconnects rather than surfacing the reason. You will observe the close as a reconnect, not as a payload. To read the reason, use a raw websocket client. `viem`/`ethers` and the pod TypeScript SDK deliver it to the subscription's error handler as shown above.
 
 ## Transaction validation messages
 

--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -1317,6 +1317,27 @@ paths:
         ```
         The `result` payload shape depends on the subscription type (see the list above).
 
+        **Server-initiated close.** The server may end a subscription on its own — most often because
+        it dropped ticks for a subscriber that fell behind, which it does rather than serve a delta
+        stream with a gap in it. That arrives on the same `eth_subscription` method with `error` in
+        place of `result`, carrying a code, whether the stream is resumable, and the `resume_since`
+        watermark to resubscribe from:
+        ```json
+        {
+          "jsonrpc": "2.0",
+          "method": "eth_subscription",
+          "params": {
+            "subscription": "0x<id>",
+            "error": { "code": -32010, "message": "…", "data": { "resumable": true, "resume_since": 1718900000000000 } }
+          }
+        }
+        ```
+        Nothing further is sent for that subscription; the connection and any other subscriptions on
+        it are unaffected. Because a delta stream never has holes, this close is the only signal that
+        data was lost — while a subscription is open, no updates means an idle market. See
+        [JSON-RPC Errors](../json-rpc-errors.md#subscription-close-notifications) for every code and
+        the recommended client response.
+
         **Filtering.** `pod_orderbook`, `pod_orders`, `pod_candles`, and `pod_markets` accept
         `orderbook_ids` (alias `clob_ids`) to restrict the stream to specific orderbooks
         (empty/omitted = all). `pod_orders` additionally accepts `bidder` to deliver only that

--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -1328,7 +1328,7 @@ paths:
           "method": "eth_subscription",
           "params": {
             "subscription": "0x<id>",
-            "error": { "code": -32010, "message": "…", "data": { "resumable": true, "resume_since": 1718900000000000 } }
+            "error": { "code": -32020, "message": "…", "data": { "resumable": true, "resume_since": 1718900000000000 } }
           }
         }
         ```


### PR DESCRIPTION
The server can end a websocket subscription on its own initiative, and until now nothing said so. Documents the frame, the four codes, and what a client should do with each.

This documents behaviour that is already merged and running: podnetwork/pod#1637, which fixed the closes being *silent* (jsonrpsee maps a subscription handler returning `Ok(())` to "send nothing", so a client kept a live socket on a subscription that would never produce again — indistinguishable from a quiet market).

The close arrives on the same `eth_subscription` method as a normal update, but with `error` in place of `result`:

```json
{
  "jsonrpc": "2.0",
  "method": "eth_subscription",
  "params": {
    "subscription": "0x9c1f…",
    "error": {
      "code": -32020,
      "message": "subscription lagged behind the tick broadcast",
      "data": { "resumable": true, "missed": 42, "resume_since": 1718900000000000 }
    }
  }
}
```

`-32020` lagged, `-32021` node shutting down, `-32022` send timeout, `-32023` serialization failure. Only the last is not resumable — an immediate resubscribe reproduces it, so clients must not hot-retry that one. `resume_since` is the watermark to pass back as `since`.

Two points worth a reviewer's eye:

**Client support is uneven, and the doc says so rather than implying it is uniform.** `alloy`'s pubsub transport rejects a notification carrying `error` and treats it as a connection error, so a Rust caller sees a reconnect rather than a reason; `jsonrpsee`'s client removes the subscription and discards the payload; and **our own TypeScript SDK does not read `params.error` yet** — a close currently reaches it as an update with an empty payload and the subscription is not dropped. That last one is tracked and needs fixing for this to be useful to TS consumers; until then the doc tells readers to treat a payload-less update as a possible close and to read the raw frame if they need the reason.

**`resume_since` semantics.** It names the newest tick the subscription is *square on* — every update it owed you was delivered, which includes a tick that matched none of your filters, since such a tick owed nothing. That wording is deliberate: the watermark has to keep advancing past non-matching ticks, because `eth_subscribe` rejects a `since` older than the retained replay buffer, so a watermark that only moved on matching ticks would go stale for a subscriber filtered to a quiet book and cost it its resume entirely.

Touches the same `eth_subscribe` description block as #256 (`pod_orders_v2`), so whichever merges second may need a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
