### PR TITLE
feat(bridge): let the upgrade script set implementation immutables

### DIFF
--- a/protocol/script/UpgradeBridge.s.sol
+++ b/protocol/script/UpgradeBridge.s.sol
@@ -14,22 +14,45 @@ contract UpgradeBridge is Script {
      *         proxy to it, preserving all storage. Does NOT touch the version,
      *         validator set, or merkle root — for a version upgrade (validator
      *         rotation) use UpdateBridgeValidatorConfig.s.sol.
+     *
+     *         Carries the current implementation's immutables over unchanged.
+     *         To repoint the bridge at a different pod-side bridge address, use
+     *         the three-argument overload.
      * @param proxyAddr The TransparentUpgradeableProxy address.
      */
     function run(address proxyAddr) external {
+        Bridge bridge = Bridge(proxyAddr);
+        _upgrade(proxyAddr, bridge.BRIDGE_CONTRACT(), bridge.CHAIN_ID());
+    }
+
+    /**
+     * @notice Code upgrade that also sets the implementation's immutables.
+     *         `BRIDGE_CONTRACT` and `CHAIN_ID` live in implementation bytecode,
+     *         not storage, so a stale value can only be corrected by deploying a
+     *         new implementation — the one-argument overload would faithfully
+     *         redeploy the stale one.
+     * @param proxyAddr The TransparentUpgradeableProxy address.
+     * @param podBridgeAddr The pod-side bridge precompile folded into claim tx hashes.
+     * @param srcChainId Pod's chain id, which feeds the claim domain separator.
+     */
+    function run(address proxyAddr, address podBridgeAddr, uint256 srcChainId) external {
+        _upgrade(proxyAddr, podBridgeAddr, srcChainId);
+    }
+
+    function _upgrade(address proxyAddr, address podBridgeAddr, uint256 srcChainId) internal {
         Bridge bridge = Bridge(proxyAddr);
 
         // Read ProxyAdmin from ERC-1967 admin slot
         address proxyAdminAddr = address(uint160(uint256(vm.load(proxyAddr, ERC1967Utils.ADMIN_SLOT))));
         console.log("ProxyAdmin:", proxyAdminAddr);
 
-        // Read immutables from current implementation
-        address podBridgeAddr = bridge.BRIDGE_CONTRACT();
-        uint256 srcChainId = bridge.CHAIN_ID();
+        address oldPodBridge = bridge.BRIDGE_CONTRACT();
+        uint256 oldChainId = bridge.CHAIN_ID();
+        uint256 currentVersion = bridge.version();
 
-        console.log("BRIDGE_CONTRACT:", podBridgeAddr);
-        console.log("CHAIN_ID:", srcChainId);
-        console.log("Current version:", bridge.version());
+        console.log("BRIDGE_CONTRACT:", oldPodBridge, "->", podBridgeAddr);
+        console.log("CHAIN_ID:", oldChainId, "->", srcChainId);
+        console.log("Current version:", currentVersion);
 
         vm.startBroadcast();
 
@@ -42,5 +65,21 @@ contract UpgradeBridge is Script {
         console.log("Proxy upgraded");
 
         vm.stopBroadcast();
+
+        require(bridge.BRIDGE_CONTRACT() == podBridgeAddr, "BRIDGE_CONTRACT not applied");
+        require(bridge.CHAIN_ID() == srcChainId, "CHAIN_ID not applied");
+
+        // `domainSeparator` is stored, derived from CHAIN_ID at the last version
+        // update. Changing CHAIN_ID therefore strands it until the next
+        // `updateValidatorConfig`, and every claim would verify against the wrong
+        // separator in the meantime — fail loudly rather than leave that live.
+        bytes32 expected =
+            keccak256(abi.encode(keccak256("pod network"), keccak256("attest_tx_bridge"), srcChainId, currentVersion));
+        require(
+            bridge.domainSeparator() == expected,
+            "stored domainSeparator no longer matches CHAIN_ID/version; re-run updateValidatorConfig"
+        );
+
+        console.log("Immutables and domain separator verified.");
     }
 }


### PR DESCRIPTION
`UpgradeBridge.s.sol` cannot change an implementation immutable. `BRIDGE_CONTRACT` and `CHAIN_ID` live in implementation bytecode rather than storage, and `run(address)` reads them off the *current* implementation before redeploying. That is correct for an ordinary code upgrade, but it means a value that needs to change cannot be — the upgrade faithfully reproduces whatever is already there.

## Change

- New `run(address,address,uint256)` overload taking the pod bridge address and chain id explicitly.
- `run(address)` unchanged — it still carries the current implementation's values over, so `upgrade_bridge.sh` and existing flows keep working. Both overloads delegate to a shared `_upgrade`.
- Both paths now assert, after the swap, that the immutables took effect and that the stored `domainSeparator` still matches `CHAIN_ID` and `version`.

That last assertion is the non-obvious one. `domainSeparator` is *storage*, computed at the last `_updateVersion`. Changing `CHAIN_ID` therefore strands it until the next `updateValidatorConfig`, and claims in the interim would verify against a separator that no longer corresponds to the chain id — a silent failure rather than a loud one. Failing the script is the better outcome.

## Verification

`forge build` is clean and both overloads appear in the ABI (`run(address)`, `run(address,address,uint256)`). Exercised against a live proxy on Arbitrum Sepolia — dry run first, then broadcast — with the immutables applied and the domain-separator assertion passing.

The change is narrow by construction: masking the four immutable spans, `forge build`'s `deployedBytecode` is byte-identical to already-deployed implementations, so the immutables are the only thing an upgrade through this path alters.

No test references this script, and the change is confined to a deployment script, so the suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)