### PR TITLE
feat(ts-sdk): stream orders from pod_orders_v2, and report the stream's transitions

### DIFF
--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -3491,7 +3491,7 @@ components:
       properties:
         k:
           type: string
-          enum: [new, reject, fill, cancel, expire, modify]
+          enum: [new, reject, fill, cancel, expire, modify, modify_reject]
           description: |
             - `new` — the order entered the book.
             - `reject` — dropped during execution, never rested; `why` carries the reason.
@@ -3499,6 +3499,7 @@ components:
             - `cancel` — removed by a cancel intent or by the engine.
             - `expire` — removed on reaching its TTL.
             - `modify` — a resting order's price and/or size changed in place.
+            - `modify_reject` — an amendment the engine refused. The order is untouched; `code` says why.
         o:
           type: integer
           description: Index into this frame's `orders`. Present when the order was created in this batch.
@@ -3510,7 +3511,34 @@ components:
           description: Index into the frame's `accts`, accompanying `id`. Present if and only if `accts` is.
         why:
           type: string
-          description: '`reject` only: why the engine dropped the order (insufficient balance or margin, off-tick price, and so on).'
+          description: |
+            On `reject`, why the engine dropped the order. On `modify_reject`, detail the `code`
+            cannot carry — the amounts on `insufficient_balance`, `invalid_price` and
+            `notional_below_minimum`, the pair on `unknown_market`, the whole reason on
+            `unspecified`. Absent for every other code, where it would restate the code.
+        by:
+          type: integer
+          description: |
+            `modify_reject` only: index into the frame's `accts` for the account that *asked*, which
+            is deliberately not `a`. A refusal says nothing about who owns the order, and on
+            `not_order_owner` the requester is precisely who does not. Absent when the subscription
+            names a single account.
+        req_px:
+          type: string
+          description: '`modify_reject` only: the price that was asked for, 1e18-scaled decimal. Echoed so a client with several amendments outstanding on one order can tell which this answers.'
+        req_sz:
+          type: string
+          description: '`modify_reject` only: the size that was asked for, 1e18-scaled decimal, unsigned.'
+        code:
+          type: string
+          enum: [insufficient_balance, invalid_price, zero_size, notional_below_minimum, unknown_market,
+                 order_not_found, not_order_owner, stale_nonce, wrong_pair, engine_managed_order,
+                 price_above_maximum, price_off_tick, market_order_must_be_ioc, size_above_maximum,
+                 size_off_lot, notional_overflow, notional_above_cap, unspecified]
+          description: |
+            `modify_reject` only: the stable reason identifier — branch on this, not on `why`.
+            Treat a value you do not recognise as `unspecified`: the set grows as the engine names
+            reasons, and `unspecified` itself means it has not named this one yet.
         b:
           type: string
           description: '`fill` only. Base filled **by this fill**, 1e18-scaled decimal — this batch''s amount, not a running total.'
@@ -3546,6 +3574,16 @@ components:
           type: string
           enum: [filled, canceled, margin_canceled, expired]
           description: '`fill` only, and only on the fill that **closed** the order, carrying the status it closed with. Its absence means the order is still working.'
+        pa:
+          type: string
+          description: |
+            `fill` on a perp market: the owner's position after this fill, 1e18-scaled **signed**
+            decimal. Absent on spot, which has no position.
+            The position *before* is not sent because it is derivable — `pa - sign(sz) * b`, the same
+            arithmetic the engine used to produce the pair — and the transition between the two is
+            what says whether the fill opened, added to, reduced, closed or flipped the position. A
+            raw position rather than a label so a client tracking positions off this stream can also
+            assert its running figure against it, the way `tb`/`tq` anchor the amounts.
         px:
           type: string
           description: '`modify` only: the order''s price after the change, 1e18-scaled decimal.'

--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -3577,8 +3577,13 @@ components:
         pa:
           type: string
           description: |
-            `fill` on a perp market: the owner's position after this fill, 1e18-scaled **signed**
-            decimal. Absent on spot, which has no position.
+            `fill`: the owner's position after this fill, 1e18-scaled **signed** decimal.
+
+            Present when a fill moved a position — so absent on spot, which has none, and absent
+            on the two fills the engine fabricates without moving one (the backstop sweep, and the
+            zero-size fill a cap-to-filled amendment emits to carry `st`). Do **not** read its
+            absence as "spot": take market type from the market. A client tracking positions treats
+            an absent `pa` as unchanged, which it is.
             The position *before* is not sent because it is derivable — `pa - sign(sz) * b`, the same
             arithmetic the engine used to produce the pair — and the transition between the two is
             what says whether the fill opened, added to, reduced, closed or flipped the position. A

--- a/ts-sdk/package-lock.json
+++ b/ts-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pod-network/trade-sdk",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pod-network/trade-sdk",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.21.0"

--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-network/trade-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Read/stream TypeScript SDK for the pod trading indexer: cacheable REST seeds + one multiplexed WebSocket, kept in memory. Framework-agnostic.",
   "type": "module",
   "sideEffects": false,

--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -211,19 +211,10 @@ export class PodTradeClient {
 
   orders(account: Address, query?: OrdersQuery): OrderHistory {
     const key = `orders:${account}:${query ? JSON.stringify(query) : ""}`;
-    // WS stream orders identify their market by token pair; resolve it against
-    // the markets list (unambiguous: base tokens are unique per market — if a
-    // pair ever matched several markets we leave orderbookId unset rather than
-    // guess). Reads the markets snapshot, so it adds no extra subscription.
-    const resolveOrderbookId = (pair: { base: Address; quote: Address }) => {
-      const base = pair.base.toLowerCase();
-      const quote = pair.quote.toLowerCase();
-      const matches = this.markets.get()?.filter((m) =>
-        m.base?.address.toLowerCase() === base && m.quote?.address.toLowerCase() === quote,
-      );
-      const only = matches && matches.length === 1 ? matches[0] : undefined;
-      return only?.id;
-    };
-    return this.memo(key, () => new OrderHistory(this.ctx, account, query, resolveOrderbookId));
+    // A streamed order names its book but not whether that book is spot or perp —
+    // that is static market metadata. Reads the markets snapshot, so it adds no
+    // extra subscription; undefined until the list has loaded.
+    const marketType = (book: MarketId) => this.markets.get()?.find((m) => m.id === book)?.type;
+    return this.memo(key, () => new OrderHistory(this.ctx, account, query, marketType));
   }
 }

--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -211,10 +211,6 @@ export class PodTradeClient {
 
   orders(account: Address, query?: OrdersQuery): OrderHistory {
     const key = `orders:${account}:${query ? JSON.stringify(query) : ""}`;
-    // A streamed order names its book but not whether that book is spot or perp —
-    // that is static market metadata. Reads the markets snapshot, so it adds no
-    // extra subscription; undefined until the list has loaded.
-    const marketType = (book: MarketId) => this.markets.get()?.find((m) => m.id === book)?.type;
-    return this.memo(key, () => new OrderHistory(this.ctx, account, query, marketType));
+    return this.memo(key, () => new OrderHistory(this.ctx, account, query));
   }
 }

--- a/ts-sdk/src/codec/decode.ts
+++ b/ts-sdk/src/codec/decode.ts
@@ -11,7 +11,7 @@ import type {
   WireMarketStatic, WireOrder, WireOrderbook, WirePartialFill, WirePerpPosition, WirePosition,
   WirePositionsSnapshot, WireSpotHolding, WireSpotPosition, WireStatus, WireTrigger,
 } from "../types/wire.js";
-import { dec, decOpt, toNumber, usToMs, usToMsOpt } from "./units.js";
+import { dec, decOpt, endMsFromUs, toNumber, usToMs, usToMsOpt } from "./units.js";
 
 export function decodeStatus(w: WireStatus): Status {
   return { solutionNow: usToMs(w.solution_now) };
@@ -80,9 +80,10 @@ export function decodeOrder(w: WireOrder): Order {
     id: w.order_id,
     txHash: w.tx_hash,
     orderbookId: w.orderbook_id,
-    marketType: w.market_type as MarketType | undefined,
-    pair: w.pair ? { base: w.pair.base, quote: w.pair.quote } : undefined,
-    // WS raw orders have no `side` field — derive it from the signed size.
+    // The order endpoints spell a perp market "perpetual"; `/clob/markets` and
+    // `MarketType` say "perp". Normalized here so one list of orders cannot carry
+    // both spellings — a streamed order takes its type from the market.
+    marketType: w.market_type === "perpetual" ? "perp" : (w.market_type as MarketType | undefined),
     side: w.side ?? (initialSize < 0n ? "sell" : "buy"),
     orderType: w.order_type,
     status: w.status as OrderStatus,
@@ -96,7 +97,7 @@ export function decodeOrder(w: WireOrder): Order {
     fee: dec(w.fee),
     effectivePrice: decOpt(w.effective_price),
     deadlineMs: usToMs(w.deadline),
-    endMs: usToMs(w.end),
+    endMs: endMsFromUs(w.end),
     includedMs: usToMsOpt(w.included_batch),
     fills: (w.fills ?? []).map(decodePartialFill),
     reduceOnly: w.reduce_only,

--- a/ts-sdk/src/codec/decode.ts
+++ b/ts-sdk/src/codec/decode.ts
@@ -262,7 +262,7 @@ export function decodeTrigger(w: WireTrigger): Trigger {
     reduceOnly: w.reduce_only,
     ioc: w.ioc,
     deadlineMs: usToMs(w.deadline),
-    endMs: usToMs(w.end),
+    endMs: endMsFromUs(w.end),
   };
 }
 

--- a/ts-sdk/src/codec/direction.test.ts
+++ b/ts-sdk/src/codec/direction.test.ts
@@ -17,10 +17,9 @@ describe("classifyPerpDirection", () => {
   });
 
   it("distinguishes opening from increasing — the whole point of sending the position", () => {
-    // Same fill size, same side; only the position it started from differs.
-    expect(classifyPerpDirection(0n, L(5))).toBe("open_long");
+    // Opening is covered above; these are the same side and size from a position that
+    // already exists, which is the only thing that distinguishes them.
     expect(classifyPerpDirection(L(3), L(8))).toBe("add_long");
-    expect(classifyPerpDirection(0n, S(5))).toBe("open_short");
     expect(classifyPerpDirection(S(3), S(8))).toBe("add_short");
   });
 

--- a/ts-sdk/src/codec/direction.test.ts
+++ b/ts-sdk/src/codec/direction.test.ts
@@ -1,0 +1,49 @@
+// Every branch of the ported classifier, in the Rust's own order. This is the whole
+// safety net for the port: the same order's direction comes from the server over REST
+// and from this function over the stream, so a branch that disagrees shows one label
+// on a live row and a different one after a refetch.
+
+import { describe, expect, it } from "vitest";
+
+import { classifyPerpDirection } from "./direction.js";
+
+const L = (n: number) => BigInt(n); // long: positive
+const S = (n: number) => BigInt(-n); // short: negative
+
+describe("classifyPerpDirection", () => {
+  it("opens from flat", () => {
+    expect(classifyPerpDirection(0n, L(5))).toBe("open_long");
+    expect(classifyPerpDirection(0n, S(5))).toBe("open_short");
+  });
+
+  it("distinguishes opening from increasing — the whole point of sending the position", () => {
+    // Same fill size, same side; only the position it started from differs.
+    expect(classifyPerpDirection(0n, L(5))).toBe("open_long");
+    expect(classifyPerpDirection(L(3), L(8))).toBe("add_long");
+    expect(classifyPerpDirection(0n, S(5))).toBe("open_short");
+    expect(classifyPerpDirection(S(3), S(8))).toBe("add_short");
+  });
+
+  it("reduces without closing", () => {
+    expect(classifyPerpDirection(L(10), L(4))).toBe("reduce_long");
+    expect(classifyPerpDirection(S(10), S(4))).toBe("reduce_short");
+  });
+
+  it("closes to flat", () => {
+    expect(classifyPerpDirection(L(10), 0n)).toBe("close_long");
+    expect(classifyPerpDirection(S(10), 0n)).toBe("close_short");
+  });
+
+  it("flips through zero", () => {
+    expect(classifyPerpDirection(L(4), S(2))).toBe("long_to_short");
+    expect(classifyPerpDirection(S(4), L(2))).toBe("short_to_long");
+  });
+
+  it("reports an unchanged position as a reduce, per the Rust", () => {
+    // Reachable when a fill nets to nothing. Odd, but matching the server matters
+    // more than picking a nicer answer here.
+    expect(classifyPerpDirection(0n, 0n)).toBe("reduce_long");
+    expect(classifyPerpDirection(L(5), L(5))).toBe("reduce_long");
+    expect(classifyPerpDirection(S(5), S(5))).toBe("reduce_short");
+  });
+});

--- a/ts-sdk/src/codec/direction.ts
+++ b/ts-sdk/src/codec/direction.ts
@@ -1,0 +1,36 @@
+// What a perp fill did to the owner's position: opened, added to, reduced, closed
+// or flipped it.
+//
+// A port of `classify_perp_order_direction` in `node/src/rpc/types.rs`, branch for
+// branch and in the same order. It exists because the two sources of an order's
+// direction have to agree: REST sends the server's label on `OrderResponse`, while
+// `pod_orders_v2` sends the raw position and leaves the classification to the
+// client. A divergence here would show one label on a streamed row and another after
+// a refetch — so this file is a transcription, not an interpretation, and the test
+// pins every branch.
+
+import type { OrderDirection } from "../types/public.js";
+
+/**
+ * Classify a position transition.
+ *
+ * `before` is not on the wire: it is `after - sign(size) * filledThisFill`, which is
+ * the same arithmetic the engine used to produce the pair (`buy_bookends` /
+ * `sell_bookends` in `trading/src/book.rs`), so deriving it loses nothing.
+ */
+export function classifyPerpDirection(before: bigint, after: bigint): OrderDirection {
+  if (before === 0n && after === 0n) return "reduce_long";
+  if (before === after) return before > 0n ? "reduce_long" : "reduce_short";
+  if (before === 0n && after > 0n) return "open_long";
+  if (before === 0n && after < 0n) return "open_short";
+  if (before > 0n && after === 0n) return "close_long";
+  if (before < 0n && after === 0n) return "close_short";
+  if (before > 0n && after < 0n) return "long_to_short";
+  if (before < 0n && after > 0n) return "short_to_long";
+  if (before > 0n && after > before) return "add_long";
+  if (before > 0n && after < before) return "reduce_long";
+  if (before < 0n && after < before) return "add_short";
+  if (before < 0n && after > before) return "reduce_short";
+  // Unreachable, and the Rust returns the same rather than erroring.
+  return "open_long";
+}

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -425,7 +425,10 @@ describe("applyOrdersFrame — reported events", () => {
     // `filledBase` change, so a consumer could only ever report their sum — and the
     // closing one hid the partial entirely.
     expect(out).toHaveLength(2);
-    expect(out[0]!.fill).toEqual({ base: WAD, quote: 100n * WAD, price: 100n * WAD, time: 1785843559500 });
+    // The running total is this fill's, not the order's after the whole frame — the two
+    // fills below would otherwise both claim the final 2.0.
+    expect(out[0]!.fill).toEqual({ base: WAD, quote: 100n * WAD, price: 100n * WAD, time: 1785843559500, totalBase: WAD });
+    expect(out[1]!.fill?.totalBase).toBe(2n * WAD);
     expect(out[0]!.fill?.closedAs).toBeUndefined();
     expect(out[1]!.fill?.closedAs).toBe("filled");
   });

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -351,7 +351,7 @@ describe("applyOrdersFrame — events", () => {
 });
 
 describe("applyOrdersFrame — refused amendments", () => {
-  it("records a refusal against the order, leaving the order itself alone", () => {
+  it("reports the refusal on the event, leaving the order itself alone", () => {
     const frame: WireOrdersFrame = {
       ...NEW_FRAME,
       orders: [],
@@ -361,14 +361,18 @@ describe("applyOrdersFrame — refused amendments", () => {
         code: "size_off_lot",
       }],
     };
-    const o = apply(frame, [resting()]).get("0xa9a5")!;
+    const seed = resting();
+    const o = apply(frame, [seed]).get("0xa9a5")!;
 
     // The amendment did not happen, so price and size are untouched — that is the
     // whole point: a refusal used to be indistinguishable from one still in flight.
     expect(o.price).toBe(100n * WAD);
     expect(o.initialSize).toBe(5n * WAD);
     expect(o.status).toBe("active");
-    expect(o.amendRejected).toEqual({
+    // And nothing about the refusal is left on the order: it describes an amendment,
+    // not the order, so it lives and dies with the event that carried it.
+    expect(Object.keys(o)).not.toContain("amendRejection");
+    expect(events(frame, [seed])[0]!.amendRejection).toEqual({
       requestedPrice: 101n * WAD,
       requestedSize: 2n * WAD,
       code: "size_off_lot",
@@ -388,11 +392,11 @@ describe("applyOrdersFrame — refused amendments", () => {
         code: "insufficient_balance", why: "need 5 have 2",
       }],
     };
-    const o = apply(frame, [resting()]).get("0xa9a5")!;
-    expect(o.amendRejected?.code).toBe("insufficient_balance");
-    expect(o.amendRejected?.message).toBe("need 5 have 2");
+    const refusal = events(frame, [resting()])[0]!.amendRejection;
+    expect(refusal?.code).toBe("insufficient_balance");
+    expect(refusal?.message).toBe("need 5 have 2");
     // A single-account stream has no accts table, so there is no index to resolve.
-    expect(o.amendRejected?.requestedBy).toBeUndefined();
+    expect(refusal?.requestedBy).toBeUndefined();
   });
 
   it("treats a code from a newer server as unspecified rather than dropping the refusal", () => {
@@ -402,9 +406,9 @@ describe("applyOrdersFrame — refused amendments", () => {
     } as unknown as WireOrdersFrame;
     // The code is open (ADR 0029 §6). Knowing an amendment was refused matters more
     // than recognising why, so the refusal is kept and the message carries what is left.
-    const o = apply(frame, [resting()]).get("0xa9a5")!;
-    expect(o.amendRejected?.code).toBe("some_future_reason");
-    expect(o.amendRejected?.message).toBe("detail");
+    const refusal = events(frame, [resting()])[0]!.amendRejection;
+    expect(refusal?.code).toBe("some_future_reason");
+    expect(refusal?.message).toBe("detail");
   });
 
   it("ignores a refusal for an order it does not hold", () => {
@@ -414,9 +418,12 @@ describe("applyOrdersFrame — refused amendments", () => {
     };
     // `order_not_found` names an order that may never have existed, so there is
     // nothing to attach the refusal to.
-    const byId = apply(frame, [resting()]);
-    expect(byId.get("0xa9a5")!.amendRejected).toBeUndefined();
+    const seed = resting();
+    const byId = apply(frame, [seed]);
     expect(byId.has("0xnotmine")).toBe(false);
+    // No order to name it against, so no event either — a consumer cannot act on a
+    // refusal whose subject it has never seen.
+    expect(events(frame, [seed])).toEqual([]);
   });
 });
 
@@ -474,7 +481,7 @@ describe("applyOrdersFrame — reported events", () => {
     // The reason rides on the order, so the event stays lean; what matters is that
     // there *is* an event for something with no state change to detect.
     expect(out.map((e) => e.kind)).toEqual(["modify_reject"]);
-    expect(out[0]!.order.amendRejected?.code).toBe("size_off_lot");
+    expect(out[0]!.amendRejection?.code).toBe("size_off_lot");
   });
 
   it("omits events it could not apply", () => {

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -78,6 +78,12 @@ function apply(frame: WireOrdersFrame, seed: Order[] = [], account = MM): Map<st
   return byId;
 }
 
+/** The events a frame reported, rather than the state it left behind. */
+function events(frame: WireOrdersFrame, seed: Order[] = [], account = MM) {
+  const byId = new Map(seed.map((o) => [o.id, o]));
+  return applyOrdersFrame(frame, byId, { account });
+}
+
 describe("applyOrdersFrame — entities", () => {
   it("decodes a captured `new` frame into orders keyed by id", () => {
     const byId = apply(NEW_FRAME);
@@ -379,6 +385,76 @@ describe("applyOrdersFrame — refused amendments", () => {
     const byId = apply(frame, [resting()]);
     expect(byId.get("0xa9a5")!.amendRejected).toBeUndefined();
     expect(byId.has("0xnotmine")).toBe(false);
+  });
+});
+
+describe("applyOrdersFrame — reported events", () => {
+  it("reports what happened, in the frame's order, with the order it happened to", () => {
+    const frame: WireOrdersFrame = {
+      ...NEW_FRAME,
+      orders: [{ id: "0xnew", tx: "0xtx", a: 0, n: 1, px: (100n * WAD).toString(), sz: (2n * WAD).toString() }],
+      events: [
+        { k: "new", o: 0 },
+        { k: "fill", o: 0, b: (2n * WAD).toString(), q: (200n * WAD).toString(), tb: (2n * WAD).toString(), tq: (200n * WAD).toString(), tf: "3", st: "filled" },
+      ],
+    };
+    const out = events(frame);
+
+    // Order preserved: a consumer sees the order enter the book and then fill, which
+    // a diff of before/after snapshots cannot distinguish from "appeared, already
+    // filled" — the events are what the engine did, not the difference they made.
+    expect(out.map((e) => e.kind)).toEqual(["new", "fill"]);
+    expect(out[0]!.order.id).toBe("0xnew");
+    expect(out[0]!.batchMs).toBe(1785843401000);
+    // Every event carries the order as the whole frame left it, so a consumer reading
+    // `order.filledBase` on the `new` event is not looking at a half-applied row.
+    expect(out[0]!.order.filledBase).toBe(2n * WAD);
+  });
+
+  it("carries this fill alone, and the status it closed with", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [
+        { k: "fill", id: "0xa9a5", b: WAD.toString(), q: (100n * WAD).toString(), tb: WAD.toString(), tq: (100n * WAD).toString(), tf: "0" },
+        { k: "fill", id: "0xa9a5", b: WAD.toString(), q: (101n * WAD).toString(), tb: (2n * WAD).toString(), tq: (201n * WAD).toString(), tf: "0", st: "filled" },
+      ],
+    };
+    const out = events(frame, [resting()]);
+
+    // Two fills in one batch stay two events. Folded into a snapshot they became one
+    // `filledBase` change, so a consumer could only ever report their sum — and the
+    // closing one hid the partial entirely.
+    expect(out).toHaveLength(2);
+    expect(out[0]!.fill).toEqual({ base: WAD, quote: 100n * WAD, price: 100n * WAD, time: 1785843559500 });
+    expect(out[0]!.fill?.closedAs).toBeUndefined();
+    expect(out[1]!.fill?.closedAs).toBe("filled");
+  });
+
+  it("reports a refusal, which changes nothing about the order", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{ k: "modify_reject", id: "0xa9a5", req_px: "1", req_sz: "1", code: "size_off_lot" }],
+    };
+    const out = events(frame, [resting()]);
+    // The reason rides on the order, so the event stays lean; what matters is that
+    // there *is* an event for something with no state change to detect.
+    expect(out.map((e) => e.kind)).toEqual(["modify_reject"]);
+    expect(out[0]!.order.amendRejected?.code).toBe("size_off_lot");
+  });
+
+  it("omits events it could not apply", () => {
+    const frame = {
+      ...MODIFY_FRAME,
+      events: [
+        { k: "cancel", id: "0xnotmine" },
+        { k: "adl_liquidation_from_a_newer_server", id: "0xa9a5" },
+        { k: "cancel", id: "0xa9a5" },
+      ],
+    } as unknown as WireOrdersFrame;
+    // An order outside the window has nothing to report against, and an unrecognised
+    // kind is ignored per ADR 0029 §6 — reporting either would hand a consumer an
+    // event it cannot act on.
+    expect(events(frame, [resting()]).map((e) => e.kind)).toEqual(["cancel"]);
   });
 });
 

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -238,6 +238,38 @@ describe("applyOrdersFrame — events", () => {
     expect(o.status).toBe("active");
   });
 
+  it("takes the status from a zero-size fill without inventing a trade for it", () => {
+    // The cap-to-filled amendment: shrinking an order to at-or-below what it had already
+    // filled leaves nothing to rest, and the engine fabricates a zero-size fill so
+    // `st: filled` reaches the indexer, which reads status from fills alone. It also
+    // names no position, which is why `pa` is absent here — and its absence must not
+    // clobber a direction earlier fills established.
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{
+        k: "fill", id: "0xa9a5", st: "filled",
+        b: "0", q: "0",
+        tb: (6n * WAD).toString(), tq: (600n * WAD).toString(), tf: "5000",
+      }],
+    };
+    const seeded = resting({
+      filledBase: 6n * WAD, filledQuote: 600n * WAD, direction: "open_long",
+      fills: [{ base: 6n * WAD, quote: 600n * WAD, price: 100n * WAD, time: 1 }],
+    });
+    const events_ = events(frame, [seeded]);
+    const o = apply(frame, [seeded]).get("0xa9a5")!;
+
+    expect(o.status).toBe("filled");
+    expect(o.filledBase).toBe(6n * WAD);
+    // One fill, the real one. A `0.0000 @ $0.00` row would read as a trade that happened.
+    expect(o.fills).toHaveLength(1);
+    expect(o.direction).toBe("open_long");
+    // The event still reports itself, so a consumer can announce the close — with the
+    // total, which is the figure that means anything here.
+    expect(events_[0]!.fill?.totalBase).toBe(6n * WAD);
+    expect(events_[0]!.fill?.closedAs).toBe("filled");
+  });
+
   it("classifies a perp fill from the position it left", () => {
     const frame: WireOrdersFrame = {
       ...MODIFY_FRAME,

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -1,0 +1,314 @@
+// The `pod_orders_v2` frame decoder. None of this is reachable from
+// `typecheck`: a frame is `unknown` off the socket, so every field mapping,
+// every "omitted means X" default and every reference form is only ever checked
+// here.
+//
+// The `new`, `expire` and `modify` frames below are verbatim captures from
+// staging (wss://staging-rpc.podtestnet.dev, 2026-08-04). Fills are synthetic:
+// staging's market maker only quotes and cancels, so no fill crossed the wire
+// in any capture window — they follow `node/src/rpc/orders_v2.rs`.
+
+import { describe, expect, it } from "vitest";
+
+import type { Address, MarketId, Order } from "../types/public.js";
+import type { WireOrdersFrame } from "../types/wire.js";
+import { applyOrdersFrame } from "./orders-v2.js";
+import { WAD } from "./units.js";
+
+const MM = "0x55dee4dad525ba46e5d99c8dfa66662160dbd4ef" as Address;
+const BOOK_7 = "0x0000000000000000000000000000000000000000000000000000000000000007" as MarketId;
+const NOW = 1_700_000_000_000;
+
+/** Captured: four quotes created in one batch on book 7, each with a TTL. */
+const NEW_FRAME: WireOrdersFrame = {
+  book: BOOK_7,
+  batch: 1785843401000000,
+  accts: [MM],
+  orders: [
+    { id: "0xb3bd", tx: "0x8018", a: 0, n: 90643, px: "209430000000000000000", sz: "2390000000000000000", end: 1785843579686000 },
+    { id: "0x32b8", tx: "0x8018", a: 0, n: 90643, px: "209840000000000000000", sz: "-2380000000000000000", end: 1785843579686000 },
+  ],
+  events: [{ k: "new", o: 0 }, { k: "new", o: 1 }],
+};
+
+/** Captured: four TTLs reached in one batch, all on orders resting from before. */
+const EXPIRE_FRAME: WireOrdersFrame = {
+  book: BOOK_7,
+  batch: 1785843399500000,
+  accts: [MM],
+  orders: [],
+  events: [{ k: "expire", id: "0x4770", a: 0 }, { k: "expire", id: "0xdead", a: 0 }],
+};
+
+/** Captured from a `bidder`-filtered stream: no `accts`, no `a`. */
+const MODIFY_FRAME: WireOrdersFrame = {
+  book: "0x0000000000000000000000000000000000000000000000000000000000000019",
+  batch: 1785843559500000,
+  orders: [],
+  events: [{ k: "modify", id: "0xa9a5", px: "37990000000000000000", sz: "175484776695621584627" }],
+};
+
+/** A resting order the frame's events can reference, as the REST seed left it. */
+function resting(over: Partial<Order> = {}): Order {
+  return {
+    id: "0xa9a5",
+    txHash: "0xf00d",
+    orderbookId: BOOK_7,
+    side: "buy",
+    orderType: "limit",
+    status: "active",
+    kind: "user_signed",
+    nonce: 7,
+    bidder: MM,
+    price: 100n * WAD,
+    initialSize: 5n * WAD,
+    filledBase: 0n,
+    filledQuote: 0n,
+    fee: 0n,
+    deadlineMs: 1785843000000,
+    fills: [],
+    ...over,
+  };
+}
+
+function apply(frame: WireOrdersFrame, seed: Order[] = [], account = MM): Map<string, Order> {
+  const byId = new Map(seed.map((o) => [o.id, o]));
+  applyOrdersFrame(frame, byId, { account, nowMs: NOW });
+  return byId;
+}
+
+describe("applyOrdersFrame — entities", () => {
+  it("decodes a captured `new` frame into orders keyed by id", () => {
+    const byId = apply(NEW_FRAME);
+
+    expect([...byId.keys()]).toEqual(["0xb3bd", "0x32b8"]);
+    const buy = byId.get("0xb3bd")!;
+    expect(buy).toMatchObject({
+      id: "0xb3bd",
+      txHash: "0x8018",
+      // The frame names the book, so the id no longer has to be inferred from a
+      // token pair — the thing v1 could not report.
+      orderbookId: BOOK_7,
+      bidder: MM,
+      nonce: 90643,
+      status: "active",
+      orderType: "limit",
+      kind: "user_signed",
+      side: "buy",
+      price: 209430000000000000000n,
+      initialSize: 2390000000000000000n,
+      filledBase: 0n,
+      filledQuote: 0n,
+      fee: 0n,
+      fills: [],
+      reduceOnly: false,
+      ioc: false,
+    });
+    // `batch` is when the order landed, which is what v1 only ever gave over REST.
+    expect(buy.includedMs).toBe(1785843401000);
+    expect(buy.endMs).toBe(1785843579686);
+  });
+
+  it("reads the side off the sign of `sz`", () => {
+    const sell = apply(NEW_FRAME).get("0x32b8")!;
+    expect(sell.side).toBe("sell");
+    expect(sell.initialSize).toBe(-2380000000000000000n);
+  });
+
+  it("takes the owner from the subscription when the frame omits `accts`", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      orders: [{ id: "0xnew1", tx: "0xtx", n: 1, px: "1", sz: "1" }],
+      events: [{ k: "new", o: 0 }],
+    };
+    // A single-account stream carries no table, so the account is the one the
+    // caller subscribed with — not undefined.
+    expect(apply(frame).get("0xnew1")!.bidder).toBe(MM);
+  });
+
+  it("treats an omitted `end` as never expiring", () => {
+    const frame: WireOrdersFrame = {
+      ...NEW_FRAME,
+      orders: [{ id: "0xnoend", tx: "0xtx", a: 0, n: 1, px: "1", sz: "1" }],
+      events: [{ k: "new", o: 0 }],
+    };
+    // Omitted rather than the u128 sentinel v1 put on the wire, so there is no
+    // 39-digit number to represent.
+    expect(apply(frame).get("0xnoend")!.endMs).toBeUndefined();
+  });
+
+  it("maps the optional entity fields, and defaults each when omitted", () => {
+    const frame: WireOrdersFrame = {
+      ...NEW_FRAME,
+      orders: [
+        { id: "0xrich", tx: "0xtx", a: 0, n: 2, px: "1", sz: "-1", kind: "triggered", type: "market", reduce_only: true, ioc: true, trigger: "stop_loss", grouping: "asset" },
+        { id: "0xplain", tx: "0xtx", a: 0, n: 3, px: "1", sz: "1" },
+      ],
+      events: [{ k: "new", o: 0 }, { k: "new", o: 1 }],
+    };
+    const byId = apply(frame);
+
+    expect(byId.get("0xrich")).toMatchObject({
+      kind: "triggered", orderType: "market", reduceOnly: true, ioc: true, triggerType: "stop_loss",
+    });
+    expect(byId.get("0xplain")).toMatchObject({
+      kind: "user_signed", orderType: "limit", reduceOnly: false, ioc: false,
+    });
+    expect(byId.get("0xplain")!.triggerType).toBeUndefined();
+  });
+
+  it("resolves the market type from the book when a resolver is given", () => {
+    const byId = new Map<string, Order>();
+    applyOrdersFrame(NEW_FRAME, byId, {
+      account: MM,
+      nowMs: NOW,
+      marketType: (book) => (book === BOOK_7 ? "perp" : undefined),
+    });
+    expect(byId.get("0xb3bd")!.marketType).toBe("perp");
+  });
+});
+
+describe("applyOrdersFrame — events", () => {
+  it("expires the orders a captured `expire` frame names, ignoring ids it does not hold", () => {
+    const byId = apply(EXPIRE_FRAME, [resting({ id: "0x4770" })]);
+
+    expect(byId.get("0x4770")!.status).toBe("expired");
+    // 0xdead rests outside the seeded window: no phantom row for an order whose
+    // terms we have never seen.
+    expect(byId.has("0xdead")).toBe(false);
+    expect(byId.size).toBe(1);
+  });
+
+  it("applies a captured `modify` in place, keeping the side", () => {
+    const byId = apply(MODIFY_FRAME, [resting({ initialSize: -5n * WAD })]);
+
+    const o = byId.get("0xa9a5")!;
+    expect(o.price).toBe(37990000000000000000n);
+    // `sz` is an unsigned magnitude, so the sign has to come from the order we
+    // already hold — decoding it as written would flip a sell to a buy.
+    expect(o.initialSize).toBe(-175484776695621584627n);
+  });
+
+  it("cancels by id", () => {
+    const frame: WireOrdersFrame = { ...MODIFY_FRAME, events: [{ k: "cancel", id: "0xa9a5" }] };
+    expect(apply(frame, [resting()]).get("0xa9a5")!.status).toBe("canceled");
+  });
+
+  it("takes the life-to-date totals a terminal event reports", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{ k: "cancel", id: "0xa9a5", tb: (2n * WAD).toString(), tq: (202n * WAD).toString(), tf: "7" }],
+    };
+    // ADR 0029 §4.1: a cancel says what the order had filled, so a partly filled
+    // order that leaves the book does not keep a stale figure.
+    const o = apply(frame, [resting({ filledBase: WAD, filledQuote: 100n * WAD })]).get("0xa9a5")!;
+    expect(o.status).toBe("canceled");
+    expect(o.filledBase).toBe(2n * WAD);
+    expect(o.filledQuote).toBe(202n * WAD);
+    expect(o.fee).toBe(7n);
+    expect(o.effectivePrice).toBe(101n * WAD);
+  });
+
+  it("reports zero filled when a terminal event says zero", () => {
+    const frame: WireOrdersFrame = { ...MODIFY_FRAME, events: [{ k: "expire", id: "0xa9a5", tb: "0", tq: "0", tf: "0" }] };
+    // An untouched order reports zeros, and zero is not absence: it must land, so
+    // a stale figure cannot survive the order leaving the book.
+    const o = apply(frame, [resting({ filledBase: 3n * WAD })]).get("0xa9a5")!;
+    expect(o.status).toBe("expired");
+    expect(o.filledBase).toBe(0n);
+  });
+
+  it("applies a partial fill from the per-fill amounts and the running totals", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{
+        k: "fill", id: "0xa9a5",
+        b: (2n * WAD).toString(), q: (200n * WAD).toString(),
+        tb: (3n * WAD).toString(), tq: (303n * WAD).toString(), tf: "5000",
+      }],
+    };
+    const o = apply(frame, [resting({ filledBase: WAD, filledQuote: 103n * WAD, fills: [{ base: WAD, quote: 103n * WAD, price: 103n * WAD, time: 1 }] })]).get("0xa9a5")!;
+
+    // Totals come from `tb`/`tq`/`tf` rather than from accumulation, so a client
+    // that missed a fill cannot drift.
+    expect(o.filledBase).toBe(3n * WAD);
+    expect(o.filledQuote).toBe(303n * WAD);
+    expect(o.fee).toBe(5000n);
+    expect(o.effectivePrice).toBe(101n * WAD);
+    // `b`/`q` are this fill alone, appended to the breakdown.
+    expect(o.fills).toHaveLength(2);
+    expect(o.fills[1]).toEqual({ base: 2n * WAD, quote: 200n * WAD, price: 100n * WAD, time: NOW });
+    // No `st`: still working.
+    expect(o.status).toBe("active");
+  });
+
+  it("closes the order on the fill that carries `st`", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{ k: "fill", id: "0xa9a5", b: "1", q: "1", tb: "1", tq: "1", tf: "0", st: "margin_canceled" }],
+    };
+    expect(apply(frame, [resting()]).get("0xa9a5")!.status).toBe("margin_canceled");
+  });
+
+  it("fills an order created in the same frame, by index", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      orders: [{ id: "0xioc", tx: "0xtx", n: 4, px: (100n * WAD).toString(), sz: (1n * WAD).toString(), type: "market", ioc: true }],
+      events: [
+        { k: "new", o: 0 },
+        { k: "fill", o: 0, b: (1n * WAD).toString(), q: (100n * WAD).toString(), tb: (1n * WAD).toString(), tq: (100n * WAD).toString(), tf: "1", st: "filled" },
+      ],
+    };
+    // A market order can be created, filled and closed inside one batch; `o`
+    // is the only way to name it, since it never rested.
+    const o = apply(frame).get("0xioc")!;
+    expect(o.status).toBe("filled");
+    expect(o.filledBase).toBe(1n * WAD);
+    expect(o.fills).toHaveLength(1);
+  });
+
+  it("records a rejected order with its reason", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      orders: [{ id: "0xbad", tx: "0xtx", n: 5, px: "1", sz: "1" }],
+      events: [{ k: "reject", o: 0, why: "insufficient balance" }],
+    };
+    const o = apply(frame).get("0xbad")!;
+    // A reject never rested, but it belongs in history — with why it failed,
+    // which v1 could only flatten into `status`.
+    expect(o.status).toBe("invalid");
+    expect(o.rejectReason).toBe("insufficient balance");
+  });
+});
+
+describe("applyOrdersFrame — forward compatibility", () => {
+  it("ignores event kinds it does not know", () => {
+    const frame = {
+      ...MODIFY_FRAME,
+      events: [
+        { k: "trigger_fired", id: "0xa9a5", something: 1 },
+        { k: "cancel", id: "0xa9a5" },
+      ],
+    } as unknown as WireOrdersFrame;
+    // ADR 0029 §6: new kinds arrive without a channel version, so an unknown one
+    // must not throw and must not stop the events after it.
+    expect(apply(frame, [resting()]).get("0xa9a5")!.status).toBe("canceled");
+  });
+
+  it("keeps an entity whose only event is a kind it does not know", () => {
+    const frame = {
+      ...MODIFY_FRAME,
+      orders: [{ id: "0xfut", tx: "0xtx", n: 6, px: "1", sz: "1" }],
+      events: [{ k: "adl", o: 0 }],
+    } as unknown as WireOrdersFrame;
+    // The order exists — the frame said so. Dropping it because the transition
+    // is from a newer server would lose a row we can otherwise display.
+    expect(apply(frame).has("0xfut")).toBe(true);
+  });
+
+  it("ignores an event that names neither `o` nor an id it holds", () => {
+    const frame = { ...MODIFY_FRAME, events: [{ k: "cancel" }] } as unknown as WireOrdersFrame;
+    expect(() => apply(frame, [resting()])).not.toThrow();
+    expect(apply(frame, [resting()]).get("0xa9a5")!.status).toBe("active");
+  });
+});

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -20,7 +20,7 @@ import { WAD } from "./units.js";
 const MM = "0x55dee4dad525ba46e5d99c8dfa66662160dbd4ef" as Address;
 const BOOK_7 = "0x0000000000000000000000000000000000000000000000000000000000000007" as MarketId;
 
-/** Captured: four quotes created in one batch on book 7, each with a TTL. */
+/** Captured (two of four): quotes created in one batch on book 7, each with a TTL. */
 const NEW_FRAME: WireOrdersFrame = {
   book: BOOK_7,
   batch: 1785843401000000,
@@ -32,7 +32,7 @@ const NEW_FRAME: WireOrdersFrame = {
   events: [{ k: "new", o: 0 }, { k: "new", o: 1 }],
 };
 
-/** Captured: four TTLs reached in one batch, all on orders resting from before. */
+/** Captured (two of four): TTLs reached in one batch, on orders resting from before. */
 const EXPIRE_FRAME: WireOrdersFrame = {
   book: BOOK_7,
   batch: 1785843399500000,
@@ -141,7 +141,7 @@ describe("applyOrdersFrame — entities", () => {
     const frame: WireOrdersFrame = {
       ...NEW_FRAME,
       orders: [
-        { id: "0xrich", tx: "0xtx", a: 0, n: 2, px: "1", sz: "-1", kind: "triggered", type: "market", reduce_only: true, ioc: true, trigger: "stop_loss", grouping: "asset" },
+        { id: "0xrich", tx: "0xtx", a: 0, n: 2, px: "1", sz: "-1", kind: "triggered", type: "market", reduce_only: true, ioc: true, trigger: "stop_loss" },
         { id: "0xplain", tx: "0xtx", a: 0, n: 3, px: "1", sz: "1" },
       ],
       events: [{ k: "new", o: 0 }, { k: "new", o: 1 }],
@@ -247,6 +247,23 @@ describe("applyOrdersFrame — events", () => {
     // is a plain sell, so the derived guess reads "Open Short".
     const o = apply(frame, [resting({ initialSize: -6n * WAD })]).get("0xa9a5")!;
     expect(o.direction).toBe("reduce_long");
+  });
+
+  it("labels a forced close by its provenance, not by the transition", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{
+        k: "fill", id: "0xa9a5",
+        b: (6n * WAD).toString(), q: (600n * WAD).toString(),
+        tb: (6n * WAD).toString(), tq: (600n * WAD).toString(), tf: "0",
+        pa: (4n * WAD).toString(),
+      }],
+    };
+    // The transition says reduce_long; REST says `liquidation`, because
+    // `order_direction_for_response` overrides the classifier for that kind. Following
+    // only the positions here would disagree with the same row after a refetch.
+    const o = apply(frame, [resting({ initialSize: -6n * WAD, kind: "liquidation" })]).get("0xa9a5")!;
+    expect(o.direction).toBe("liquidation");
   });
 
   it("leaves direction unset on a spot fill, which reports no position", () => {
@@ -392,7 +409,6 @@ describe("applyOrdersFrame — forward compatibility", () => {
 
   it("ignores an event that names neither `o` nor an id it holds", () => {
     const frame = { ...MODIFY_FRAME, events: [{ k: "cancel" }] } as unknown as WireOrdersFrame;
-    expect(() => apply(frame, [resting()])).not.toThrow();
     expect(apply(frame, [resting()]).get("0xa9a5")!.status).toBe("active");
   });
 });

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -86,8 +86,7 @@ describe("applyOrdersFrame — entities", () => {
     expect(buy).toMatchObject({
       id: "0xb3bd",
       txHash: "0x8018",
-      // The frame names the book, so the id no longer has to be inferred from a
-      // token pair — the thing v1 could not report.
+      // The frame names the book, so the id is stated rather than inferred.
       orderbookId: BOOK_7,
       bidder: MM,
       nonce: 90643,
@@ -104,7 +103,7 @@ describe("applyOrdersFrame — entities", () => {
       reduceOnly: false,
       ioc: false,
     });
-    // `batch` is when the order landed, which is what v1 only ever gave over REST.
+    // `batch` is when the order landed — inclusion time, on a streamed order.
     expect(buy.includedMs).toBe(1785843401000);
     expect(buy.endMs).toBe(1785843579686);
   });
@@ -132,8 +131,8 @@ describe("applyOrdersFrame — entities", () => {
       orders: [{ id: "0xnoend", tx: "0xtx", a: 0, n: 1, px: "1", sz: "1" }],
       events: [{ k: "new", o: 0 }],
     };
-    // Omitted rather than the u128 sentinel v1 put on the wire, so there is no
-    // 39-digit number to represent.
+    // Omitted rather than sent as a u128 sentinel, so there is no 39-digit
+    // number for a JS consumer to represent.
     expect(apply(frame).get("0xnoend")!.endMs).toBeUndefined();
   });
 
@@ -155,16 +154,6 @@ describe("applyOrdersFrame — entities", () => {
       kind: "user_signed", orderType: "limit", reduceOnly: false, ioc: false,
     });
     expect(byId.get("0xplain")!.triggerType).toBeUndefined();
-  });
-
-  it("resolves the market type from the book when a resolver is given", () => {
-    const byId = new Map<string, Order>();
-    applyOrdersFrame(NEW_FRAME, byId, {
-      account: MM,
-      nowMs: NOW,
-      marketType: (book) => (book === BOOK_7 ? "perp" : undefined),
-    });
-    expect(byId.get("0xb3bd")!.marketType).toBe("perp");
   });
 });
 
@@ -274,8 +263,7 @@ describe("applyOrdersFrame — events", () => {
       events: [{ k: "reject", o: 0, why: "insufficient balance" }],
     };
     const o = apply(frame).get("0xbad")!;
-    // A reject never rested, but it belongs in history — with why it failed,
-    // which v1 could only flatten into `status`.
+    // A reject never rested, but it belongs in history — with why it failed.
     expect(o.status).toBe("invalid");
     expect(o.rejectReason).toBe("insufficient balance");
   });

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -231,6 +231,31 @@ describe("applyOrdersFrame — events", () => {
     expect(o.status).toBe("active");
   });
 
+  it("classifies a perp fill from the position it left", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{
+        k: "fill", id: "0xa9a5",
+        b: (6n * WAD).toString(), q: (600n * WAD).toString(),
+        tb: (6n * WAD).toString(), tq: (600n * WAD).toString(), tf: "0",
+        pa: (4n * WAD).toString(),
+      }],
+    };
+    // A sell of 6 that left the owner at +4 must have started at +10, so it reduced a
+    // long. That is the label the order's own side and `reduceOnly` cannot reach: it
+    // is a plain sell, so the derived guess reads "Open Short".
+    const o = apply(frame, [resting({ initialSize: -6n * WAD })]).get("0xa9a5")!;
+    expect(o.direction).toBe("reduce_long");
+  });
+
+  it("leaves direction unset on a spot fill, which reports no position", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{ k: "fill", id: "0xa9a5", b: "1", q: "1", tb: "1", tq: "1", tf: "0" }],
+    };
+    expect(apply(frame, [resting()]).get("0xa9a5")!.direction).toBeUndefined();
+  });
+
   it("closes the order on the fill that carries `st`", () => {
     const frame: WireOrdersFrame = {
       ...MODIFY_FRAME,

--- a/ts-sdk/src/codec/orders-v2.test.ts
+++ b/ts-sdk/src/codec/orders-v2.test.ts
@@ -4,9 +4,11 @@
 // here.
 //
 // The `new`, `expire` and `modify` frames below are verbatim captures from
-// staging (wss://staging-rpc.podtestnet.dev, 2026-08-04). Fills are synthetic:
-// staging's market maker only quotes and cancels, so no fill crossed the wire
-// in any capture window — they follow `node/src/rpc/orders_v2.rs`.
+// staging (wss://staging-rpc.podtestnet.dev, 2026-08-04). Fill, position and
+// modify_reject cases are written from `node/src/rpc/orders_v2.rs` instead: staging
+// only began crossing trades later, and its deployed build predates both `pa` and
+// `modify_reject`, so those shapes have no captured bytes yet. Replacing them with
+// captures is worth doing once a node build carries the fields.
 
 import { describe, expect, it } from "vitest";
 
@@ -17,7 +19,6 @@ import { WAD } from "./units.js";
 
 const MM = "0x55dee4dad525ba46e5d99c8dfa66662160dbd4ef" as Address;
 const BOOK_7 = "0x0000000000000000000000000000000000000000000000000000000000000007" as MarketId;
-const NOW = 1_700_000_000_000;
 
 /** Captured: four quotes created in one batch on book 7, each with a TTL. */
 const NEW_FRAME: WireOrdersFrame = {
@@ -73,7 +74,7 @@ function resting(over: Partial<Order> = {}): Order {
 
 function apply(frame: WireOrdersFrame, seed: Order[] = [], account = MM): Map<string, Order> {
   const byId = new Map(seed.map((o) => [o.id, o]));
-  applyOrdersFrame(frame, byId, { account, nowMs: NOW });
+  applyOrdersFrame(frame, byId, { account });
   return byId;
 }
 
@@ -226,7 +227,7 @@ describe("applyOrdersFrame — events", () => {
     expect(o.effectivePrice).toBe(101n * WAD);
     // `b`/`q` are this fill alone, appended to the breakdown.
     expect(o.fills).toHaveLength(2);
-    expect(o.fills[1]).toEqual({ base: 2n * WAD, quote: 200n * WAD, price: 100n * WAD, time: NOW });
+    expect(o.fills[1]).toEqual({ base: 2n * WAD, quote: 200n * WAD, price: 100n * WAD, time: 1785843559500 });
     // No `st`: still working.
     expect(o.status).toBe("active");
   });
@@ -291,6 +292,76 @@ describe("applyOrdersFrame — events", () => {
     // A reject never rested, but it belongs in history — with why it failed.
     expect(o.status).toBe("invalid");
     expect(o.rejectReason).toBe("insufficient balance");
+  });
+});
+
+describe("applyOrdersFrame — refused amendments", () => {
+  it("records a refusal against the order, leaving the order itself alone", () => {
+    const frame: WireOrdersFrame = {
+      ...NEW_FRAME,
+      orders: [],
+      events: [{
+        k: "modify_reject", id: "0xa9a5", by: 0,
+        req_px: (101n * WAD).toString(), req_sz: (2n * WAD).toString(),
+        code: "size_off_lot",
+      }],
+    };
+    const o = apply(frame, [resting()]).get("0xa9a5")!;
+
+    // The amendment did not happen, so price and size are untouched — that is the
+    // whole point: a refusal used to be indistinguishable from one still in flight.
+    expect(o.price).toBe(100n * WAD);
+    expect(o.initialSize).toBe(5n * WAD);
+    expect(o.status).toBe("active");
+    expect(o.amendRejected).toEqual({
+      requestedPrice: 101n * WAD,
+      requestedSize: 2n * WAD,
+      code: "size_off_lot",
+      message: undefined,
+      // `by` is the requester, resolved through the frame's accts table.
+      requestedBy: MM,
+      batchMs: 1785843401000,
+    });
+  });
+
+  it("keeps the message when the code cannot carry the detail", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{
+        k: "modify_reject", id: "0xa9a5",
+        req_px: "1", req_sz: "1",
+        code: "insufficient_balance", why: "need 5 have 2",
+      }],
+    };
+    const o = apply(frame, [resting()]).get("0xa9a5")!;
+    expect(o.amendRejected?.code).toBe("insufficient_balance");
+    expect(o.amendRejected?.message).toBe("need 5 have 2");
+    // A single-account stream has no accts table, so there is no index to resolve.
+    expect(o.amendRejected?.requestedBy).toBeUndefined();
+  });
+
+  it("treats a code from a newer server as unspecified rather than dropping the refusal", () => {
+    const frame = {
+      ...MODIFY_FRAME,
+      events: [{ k: "modify_reject", id: "0xa9a5", req_px: "1", req_sz: "1", code: "some_future_reason", why: "detail" }],
+    } as unknown as WireOrdersFrame;
+    // The code is open (ADR 0029 §6). Knowing an amendment was refused matters more
+    // than recognising why, so the refusal is kept and the message carries what is left.
+    const o = apply(frame, [resting()]).get("0xa9a5")!;
+    expect(o.amendRejected?.code).toBe("some_future_reason");
+    expect(o.amendRejected?.message).toBe("detail");
+  });
+
+  it("ignores a refusal for an order it does not hold", () => {
+    const frame: WireOrdersFrame = {
+      ...MODIFY_FRAME,
+      events: [{ k: "modify_reject", id: "0xnotmine", req_px: "1", req_sz: "1", code: "order_not_found" }],
+    };
+    // `order_not_found` names an order that may never have existed, so there is
+    // nothing to attach the refusal to.
+    const byId = apply(frame, [resting()]);
+    expect(byId.get("0xa9a5")!.amendRejected).toBeUndefined();
+    expect(byId.has("0xnotmine")).toBe(false);
   });
 });
 

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -6,7 +6,9 @@
 // them and to orders already held. Status lives only in the events, which is what
 // lets the server add transition kinds without changing the entity.
 
-import type { Address, Order, OrderStatus, PartialFill, RejectCode } from "../types/public.js";
+import type {
+  Address, Order, OrderEvent, OrderEventKind, OrderStatus, PartialFill, RejectCode,
+} from "../types/public.js";
 import type { WireOrderEntity, WireOrderEvent, WireOrdersFrame } from "../types/wire.js";
 import { dec, endMsFromUs, usToMs } from "./units.js";
 import { div } from "./fixed.js";
@@ -24,18 +26,23 @@ interface FrameFacts {
 }
 
 /**
- * Fold one frame into `byId`, in place.
+ * Fold one frame into `byId`, in place, and report the transitions it applied.
  *
  * Events naming an order that is not in `byId` and not in this frame are skipped:
  * they belong to an order resting outside the caller's window, and its terms have
- * never been on the wire, so there is nothing to display.
+ * never been on the wire, so there is nothing to display — and nothing to report.
+ *
+ * The returned events carry the order as the *whole* frame left it, not as it stood
+ * mid-frame: they are collected while applying but the rows are mutated in place, so a
+ * consumer never sees a half-applied order.
  */
-export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order>, ctx: OrdersFrameContext): void {
+export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order>, ctx: OrdersFrameContext): OrderEvent[] {
   // The book and the batch are frame constants: resolved once, not per entity.
   const batchMs = usToMs(frame.batch);
   const facts: FrameFacts = { batchMs, accts: frame.accts };
   const created = frame.orders.map((e) => decodeEntity(e, frame, batchMs, ctx.account));
 
+  const applied: OrderEvent[] = [];
   for (const event of frame.events) {
     // `o` indexes this frame's entities and `id` names one resting from an earlier
     // batch — but an event kind added later (ADR 0029 §6 reserves several) may name
@@ -46,7 +53,12 @@ export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order
       ? created[event.o]
       : byId.get(event.id ?? "") ?? created.find((o) => o.id === event.id);
     if (!target) continue;
-    applyEvent(event, target, facts);
+    const fill = applyEvent(event, target, facts);
+    // Only kinds this version understands: an unrecognised one is ignored rather than
+    // handed on as an event a consumer cannot act on (ADR 0029 §6).
+    if (KNOWN_KINDS.has(event.k)) {
+      applied.push({ kind: event.k as OrderEventKind, order: target, batchMs, ...(fill && { fill }) });
+    }
   }
 
   // After the events, not before: an entity's own `new`/`reject` decides the
@@ -54,6 +66,7 @@ export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order
   // understands are still inserted — the frame said the order exists, and a
   // transition from a newer server is no reason to drop the row.
   for (const order of created) byId.set(order.id, order);
+  return applied;
 }
 
 function decodeEntity(e: WireOrderEntity, frame: WireOrdersFrame, batchMs: number, account: Address): Order {
@@ -112,7 +125,12 @@ function applyTotals(event: WireOrderEvent, order: Order): void {
   order.effectivePrice = order.filledBase > 0n ? div(order.filledQuote, order.filledBase) : undefined;
 }
 
-function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): void {
+const KNOWN_KINDS = new Set<string>([
+  "new", "reject", "fill", "cancel", "expire", "modify", "modify_reject",
+]);
+
+/** Apply one event, returning the fill it recorded when it was a fill. */
+function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): (PartialFill & { closedAs?: OrderStatus }) | undefined {
   switch (event.k) {
     case "new":
       order.status = "active";
@@ -161,7 +179,7 @@ function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): voi
       }
       // Present only on the fill that closed the order.
       if (event.st) order.status = event.st as OrderStatus;
-      break;
+      return { ...fill, closedAs: event.st as OrderStatus | undefined };
     }
     case "modify_reject":
       // The order is untouched: this answers an amendment that did not happen. Without

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -8,7 +8,8 @@
 
 import type { Address, Order, OrderStatus, PartialFill, RejectCode } from "../types/public.js";
 import type { WireOrderEntity, WireOrderEvent, WireOrdersFrame } from "../types/wire.js";
-import { dec, endMsFromUs, usToMs, WAD } from "./units.js";
+import { dec, endMsFromUs, usToMs } from "./units.js";
+import { div } from "./fixed.js";
 import { classifyPerpDirection } from "./direction.js";
 
 export interface OrdersFrameContext {
@@ -16,15 +17,11 @@ export interface OrdersFrameContext {
   account: Address;
 }
 
-/** Per-frame facts the events need: the batch they landed in and who they belong to. */
+/** Per-frame facts the events need. */
 interface FrameFacts {
   batchMs: number;
   accts?: WireOrdersFrame["accts"];
-  account: Address;
 }
-
-/** Volume-weighted price of a filled amount; zero base has no price. */
-const vwap = (quote: bigint, base: bigint) => (base > 0n ? (quote * WAD) / base : 0n);
 
 /**
  * Fold one frame into `byId`, in place.
@@ -36,7 +33,7 @@ const vwap = (quote: bigint, base: bigint) => (base > 0n ? (quote * WAD) / base 
 export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order>, ctx: OrdersFrameContext): void {
   // The book and the batch are frame constants: resolved once, not per entity.
   const batchMs = usToMs(frame.batch);
-  const facts: FrameFacts = { batchMs, accts: frame.accts, account: ctx.account };
+  const facts: FrameFacts = { batchMs, accts: frame.accts };
   const created = frame.orders.map((e) => decodeEntity(e, frame, batchMs, ctx.account));
 
   for (const event of frame.events) {
@@ -112,7 +109,7 @@ function applyTotals(event: WireOrderEvent, order: Order): void {
   order.fee = dec(event.tf);
   // Cleared, not skipped, when nothing is filled: a row reporting zero filled beside
   // a fill price from before is worse than one with no fill price.
-  order.effectivePrice = order.filledBase > 0n ? vwap(order.filledQuote, order.filledBase) : undefined;
+  order.effectivePrice = order.filledBase > 0n ? div(order.filledQuote, order.filledBase) : undefined;
 }
 
 function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): void {
@@ -145,7 +142,7 @@ function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): voi
       // auction's own timestamp rather than when this client happened to read it.
       const base = dec(event.b);
       const quote = dec(event.q);
-      const fill: PartialFill = { base, quote, price: vwap(quote, base), time: facts.batchMs };
+      const fill: PartialFill = { base, quote, price: div(quote, base), time: facts.batchMs };
       order.fills = [...order.fills, fill];
       // A perp fill reports the position it left. The position it started from is
       // that minus what this fill moved it — a buy raises it, a sell lowers it — and
@@ -156,7 +153,11 @@ function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): voi
       if (event.pa !== undefined) {
         const after = dec(event.pa);
         const before = after - (order.initialSize < 0n ? -base : base);
-        order.direction = classifyPerpDirection(before, after);
+        // A forced close is labelled by how it came about, not by the transition it
+        // made — `order_direction_for_response` overrides the classifier the same way,
+        // and without this a liquidation reads `close_long` here and `liquidation`
+        // after a REST refetch.
+        order.direction = order.kind === "liquidation" ? "liquidation" : classifyPerpDirection(before, after);
       }
       // Present only on the fill that closed the order.
       if (event.st) order.status = event.st as OrderStatus;

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -160,7 +160,11 @@ function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): { f
       const base = dec(event.b);
       const quote = dec(event.q);
       const fill: PartialFill = { base, quote, price: div(quote, base), time: facts.batchMs };
-      order.fills = [...order.fills, fill];
+      // A real fill always has size. A zero-size one is the engine flipping status: the
+      // cap-to-filled amendment fabricates it so `st: filled` reaches the indexer, which
+      // reads status from fills alone. Its totals and status count; adding a
+      // `0.0000 @ $0.00` row to the order's fill history would only invent a trade.
+      if (base !== 0n) order.fills = [...order.fills, fill];
       // A perp fill reports the position it left. The position it started from is
       // that minus what this fill moved it — a buy raises it, a sell lowers it — and
       // the transition is what says whether the order opened, added to, reduced,

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -9,6 +9,7 @@
 import type { Address, Order, OrderStatus, PartialFill } from "../types/public.js";
 import type { WireOrderEntity, WireOrderEvent, WireOrdersFrame } from "../types/wire.js";
 import { dec, endMsFromUs, usToMs, WAD } from "./units.js";
+import { classifyPerpDirection } from "./direction.js";
 
 export interface OrdersFrameContext {
   /** The account the subscription is filtered to, used when the frame omits `accts`. */
@@ -140,6 +141,17 @@ function applyEvent(event: WireOrderEvent, order: Order, nowMs: number): void {
       const quote = dec(event.q);
       const fill: PartialFill = { base, quote, price: vwap(quote, base), time: nowMs };
       order.fills = [...order.fills, fill];
+      // A perp fill reports the position it left. The position it started from is
+      // that minus what this fill moved it — a buy raises it, a sell lowers it — and
+      // the transition is what says whether the order opened, added to, reduced,
+      // closed or flipped. Without it a client can only guess from the order's own
+      // side and `reduceOnly`, which calls a plain sell that closed a long an
+      // "Open Short".
+      if (event.pa !== undefined) {
+        const after = dec(event.pa);
+        const before = after - (order.initialSize < 0n ? -base : base);
+        order.direction = classifyPerpDirection(before, after);
+      }
       // Present only on the fill that closed the order.
       if (event.st) order.status = event.st as OrderStatus;
       break;

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -7,8 +7,8 @@
 // lets the server add transition kinds without changing the entity.
 
 import type {
-  Address, Order, OrderEvent, OrderEventFill, OrderEventKind, OrderStatus, PartialFill,
-  RejectCode, TerminalStatus,
+  Address, AmendRejection, Order, OrderEvent, OrderEventFill, OrderEventKind, OrderStatus,
+  PartialFill, RejectCode, TerminalStatus,
 } from "../types/public.js";
 import type { WireOrderEntity, WireOrderEvent, WireOrdersFrame } from "../types/wire.js";
 import { dec, endMsFromUs, usToMs } from "./units.js";
@@ -58,7 +58,15 @@ export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order
     // handed on as an event a consumer cannot act on (ADR 0029 §6). The switch is the
     // only list of what is recognised — a separate one could disagree with it.
     const outcome = applyEvent(event, target, facts);
-    if (outcome) applied.push({ kind: event.k as OrderEventKind, order: target, batchMs, fill: outcome.fill });
+    if (outcome) {
+      applied.push({
+        kind: event.k as OrderEventKind,
+        order: target,
+        batchMs,
+        fill: outcome.fill,
+        amendRejection: outcome.amendRejection,
+      });
+    }
   }
 
   // After the events, not before: an entity's own `new`/`reject` decides the
@@ -126,10 +134,14 @@ function applyTotals(event: WireOrderEvent, order: Order): void {
 }
 
 /**
- * Apply one event. `undefined` when the kind is not one this version knows; otherwise
- * what the event contributed, which for a fill is the fill itself.
+ * Apply one event. `undefined` when the kind is not one this version knows; otherwise what
+ * the event contributed beyond the order's own state — the fill, or the refused amendment.
  */
-function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): { fill?: OrderEventFill } | undefined {
+function applyEvent(
+  event: WireOrderEvent,
+  order: Order,
+  facts: FrameFacts,
+): { fill?: OrderEventFill; amendRejection?: AmendRejection } | undefined {
   switch (event.k) {
     case "new":
       order.status = "active";
@@ -189,19 +201,21 @@ function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): { f
       };
     }
     case "modify_reject":
-      // The order is untouched: this answers an amendment that did not happen. Without
-      // it a refused price change looks exactly like one still in flight. `by` is the
-      // requester, not the owner — on `not_order_owner` it is precisely who does not
-      // own the order — so it is resolved separately from `a`.
-      order.amendRejected = {
-        requestedPrice: dec(event.req_px),
-        requestedSize: dec(event.req_sz),
-        code: (event.code ?? "unspecified") as RejectCode,
-        message: event.why,
-        requestedBy: event.by !== undefined ? facts.accts?.[event.by] : undefined,
-        batchMs: facts.batchMs,
+      // Reported, not applied: this answers an amendment that did not happen, so the order
+      // is left exactly as it was — which is also why it belongs to the event and not to
+      // the order. Without it a refused price change looks like one still in flight.
+      // `by` is the requester, not the owner — on `not_order_owner` it is precisely who
+      // does not own the order — so it is resolved separately from `a`.
+      return {
+        amendRejection: {
+          requestedPrice: dec(event.req_px),
+          requestedSize: dec(event.req_sz),
+          code: (event.code ?? "unspecified") as RejectCode,
+          message: event.why,
+          requestedBy: event.by !== undefined ? facts.accts?.[event.by] : undefined,
+          batchMs: facts.batchMs,
+        },
       };
-      return {};
     // ADR 0029 §6: kinds are open, so an unrecognised one falls through to
     // `undefined` — applied to nothing, reported to nobody.
   }

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -1,0 +1,135 @@
+// `pod_orders_v2` frames -> the public `Order` map (ADR 0029).
+//
+// A frame is entity/event shaped: identity and terms cross the wire once, in
+// `orders`, and everything after that is a reference. So decoding is two passes —
+// materialize this batch's entities, then let the events say what happened to
+// them and to orders already held. Status lives only in the events, which is what
+// lets the server add transition kinds without changing the entity.
+
+import type { Address, MarketId, MarketType, Order, OrderStatus, PartialFill } from "../types/public.js";
+import type { WireOrderEntity, WireOrderEvent, WireOrdersFrame } from "../types/wire.js";
+import { dec, endMsFromUs, usToMs, WAD } from "./units.js";
+
+export interface OrdersFrameContext {
+  /** The account the subscription is filtered to, used when the frame omits `accts`. */
+  account: Address;
+  /** Market type for a book, when the markets list has loaded. */
+  marketType?: (book: MarketId) => MarketType | undefined;
+  /** Receipt time (ms) stamped on this frame's fills — the wire carries none. */
+  nowMs: number;
+}
+
+/**
+ * Fold one frame into `byId`, in place.
+ *
+ * Events naming an order that is not in `byId` and not in this frame are skipped:
+ * they belong to an order resting outside the caller's window, and its terms have
+ * never been on the wire, so there is nothing to display.
+ */
+export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order>, ctx: OrdersFrameContext): void {
+  const created = frame.orders.map((e) => decodeEntity(e, frame, ctx));
+
+  for (const event of frame.events) {
+    const target = event.o !== undefined ? created[event.o] : byId.get(event.id ?? "");
+    if (!target) continue;
+    applyEvent(event, target, ctx.nowMs);
+  }
+
+  // After the events, not before: an entity's own `new`/`reject` decides the
+  // status it lands with. Entities left untouched by every event this version
+  // understands are still inserted — the frame said the order exists, and a
+  // transition from a newer server is no reason to drop the row.
+  for (const order of created) byId.set(order.id, order);
+}
+
+function decodeEntity(e: WireOrderEntity, frame: WireOrdersFrame, ctx: OrdersFrameContext): Order {
+  const initialSize = dec(e.sz);
+  const batchMs = usToMs(frame.batch);
+  return {
+    id: e.id,
+    txHash: e.tx,
+    // The frame names the book, so this is exact — v1 carried a token pair and
+    // left the id to be inferred from the markets list.
+    orderbookId: frame.book,
+    marketType: ctx.marketType?.(frame.book),
+    side: initialSize < 0n ? "sell" : "buy",
+    orderType: e.type === "market" ? "market" : "limit",
+    // Not on the entity: an order that rests is `active`, and the events below
+    // move it from there.
+    status: "active",
+    kind: (e.kind ?? "user_signed") as Order["kind"],
+    nonce: e.n,
+    // A frame with no `accts` covers exactly one account, so every row is its.
+    bidder: (frame.accts && e.a !== undefined ? frame.accts[e.a] : ctx.account) as Address,
+    price: dec(e.px),
+    initialSize,
+    filledBase: 0n,
+    filledQuote: 0n,
+    fee: 0n,
+    // The signed deadline is not on the v2 wire. The batch the order landed in is
+    // at or before it, which is what ordering and display need; the REST re-seed
+    // replaces this with the signed value.
+    deadlineMs: batchMs,
+    endMs: endMsFromUs(e.end),
+    includedMs: batchMs,
+    fills: [],
+    reduceOnly: e.reduce_only ?? false,
+    ioc: e.ioc ?? false,
+    triggerType: e.trigger as Order["triggerType"],
+  };
+}
+
+/**
+ * Take the order's life-to-date totals off the event that reports them.
+ *
+ * Every fill, cancel and expiry carries all three, zero included (ADR 0029 §4.1) —
+ * so they are read unconditionally, and an order that leaves the book reports what
+ * it filled rather than keeping whatever it last had. Authoritative rather than
+ * accumulated, so a client that missed a fill cannot drift.
+ */
+function applyTotals(event: WireOrderEvent, order: Order): void {
+  order.filledBase = dec(event.tb);
+  order.filledQuote = dec(event.tq);
+  order.fee = dec(event.tf);
+  if (order.filledBase > 0n) order.effectivePrice = (order.filledQuote * WAD) / order.filledBase;
+}
+
+function applyEvent(event: WireOrderEvent, order: Order, nowMs: number): void {
+  switch (event.k) {
+    case "new":
+      order.status = "active";
+      break;
+    case "reject":
+      order.status = "invalid";
+      order.rejectReason = event.why;
+      break;
+    case "cancel":
+      order.status = "canceled";
+      applyTotals(event, order);
+      break;
+    case "expire":
+      order.status = "expired";
+      applyTotals(event, order);
+      break;
+    case "modify": {
+      order.price = dec(event.px);
+      // `sz` is an unsigned magnitude, so the side comes from the order we hold.
+      const sign = order.initialSize < 0n ? -1n : 1n;
+      order.initialSize = sign * dec(event.sz);
+      break;
+    }
+    case "fill": {
+      applyTotals(event, order);
+      // `b`/`q` are this fill alone. The wire carries no per-fill timestamp, so
+      // receipt time is the closest thing available.
+      const base = dec(event.b);
+      const quote = dec(event.q);
+      const fill: PartialFill = { base, quote, price: base > 0n ? (quote * WAD) / base : 0n, time: nowMs };
+      order.fills = [...order.fills, fill];
+      // Present only on the fill that closed the order.
+      if (event.st) order.status = event.st as OrderStatus;
+      break;
+    }
+    // ADR 0029 §6: kinds are open. An unrecognised one is ignored, not an error.
+  }
+}

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -69,11 +69,11 @@ function decodeEntity(e: WireOrderEntity, frame: WireOrdersFrame, batchMs: numbe
     filledBase: 0n,
     filledQuote: 0n,
     fee: 0n,
-    // The signed deadline is not on the v2 wire. The batch the order landed in is
-    // at or before it, which is what ordering and display need; the REST re-seed
-    // replaces this with the signed value.
-    deadlineMs: batchMs,
     endMs: endMsFromUs(e.end),
+    // When the order became real. The signed deadline is not on this wire and is
+    // deliberately not invented from the batch: REST reports both separately, so
+    // inclusion time is the one thing every source agrees on and the only honest
+    // key to order by.
     includedMs: batchMs,
     fills: [],
     reduceOnly: e.reduce_only ?? false,

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -180,7 +180,9 @@ function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): { f
       if (event.st) order.status = event.st as OrderStatus;
       // Copied rather than shared: the same object is in `order.fills`, and attaching a
       // per-event field to it would leak the event into the order's fill history.
-      return { fill: { ...fill, closedAs: event.st as TerminalStatus | undefined } };
+      return {
+        fill: { ...fill, totalBase: dec(event.tb), closedAs: event.st as TerminalStatus | undefined },
+      };
     }
     case "modify_reject":
       // The order is untouched: this answers an amendment that did not happen. Without

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -6,7 +6,7 @@
 // them and to orders already held. Status lives only in the events, which is what
 // lets the server add transition kinds without changing the entity.
 
-import type { Address, Order, OrderStatus, PartialFill } from "../types/public.js";
+import type { Address, Order, OrderStatus, PartialFill, RejectCode } from "../types/public.js";
 import type { WireOrderEntity, WireOrderEvent, WireOrdersFrame } from "../types/wire.js";
 import { dec, endMsFromUs, usToMs, WAD } from "./units.js";
 import { classifyPerpDirection } from "./direction.js";
@@ -14,8 +14,13 @@ import { classifyPerpDirection } from "./direction.js";
 export interface OrdersFrameContext {
   /** The account the subscription is filtered to, used when the frame omits `accts`. */
   account: Address;
-  /** Receipt time (ms) stamped on this frame's fills — the wire carries none. */
-  nowMs: number;
+}
+
+/** Per-frame facts the events need: the batch they landed in and who they belong to. */
+interface FrameFacts {
+  batchMs: number;
+  accts?: WireOrdersFrame["accts"];
+  account: Address;
 }
 
 /** Volume-weighted price of a filled amount; zero base has no price. */
@@ -31,6 +36,7 @@ const vwap = (quote: bigint, base: bigint) => (base > 0n ? (quote * WAD) / base 
 export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order>, ctx: OrdersFrameContext): void {
   // The book and the batch are frame constants: resolved once, not per entity.
   const batchMs = usToMs(frame.batch);
+  const facts: FrameFacts = { batchMs, accts: frame.accts, account: ctx.account };
   const created = frame.orders.map((e) => decodeEntity(e, frame, batchMs, ctx.account));
 
   for (const event of frame.events) {
@@ -43,7 +49,7 @@ export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order
       ? created[event.o]
       : byId.get(event.id ?? "") ?? created.find((o) => o.id === event.id);
     if (!target) continue;
-    applyEvent(event, target, ctx.nowMs);
+    applyEvent(event, target, facts);
   }
 
   // After the events, not before: an entity's own `new`/`reject` decides the
@@ -109,7 +115,7 @@ function applyTotals(event: WireOrderEvent, order: Order): void {
   order.effectivePrice = order.filledBase > 0n ? vwap(order.filledQuote, order.filledBase) : undefined;
 }
 
-function applyEvent(event: WireOrderEvent, order: Order, nowMs: number): void {
+function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): void {
   switch (event.k) {
     case "new":
       order.status = "active";
@@ -135,11 +141,11 @@ function applyEvent(event: WireOrderEvent, order: Order, nowMs: number): void {
     }
     case "fill": {
       applyTotals(event, order);
-      // `b`/`q` are this fill alone. The wire carries no per-fill timestamp, so
-      // receipt time is the closest thing available.
+      // `b`/`q` are this fill alone, and its time is the batch it cleared in — the
+      // auction's own timestamp rather than when this client happened to read it.
       const base = dec(event.b);
       const quote = dec(event.q);
-      const fill: PartialFill = { base, quote, price: vwap(quote, base), time: nowMs };
+      const fill: PartialFill = { base, quote, price: vwap(quote, base), time: facts.batchMs };
       order.fills = [...order.fills, fill];
       // A perp fill reports the position it left. The position it started from is
       // that minus what this fill moved it — a buy raises it, a sell lowers it — and
@@ -156,6 +162,20 @@ function applyEvent(event: WireOrderEvent, order: Order, nowMs: number): void {
       if (event.st) order.status = event.st as OrderStatus;
       break;
     }
+    case "modify_reject":
+      // The order is untouched: this answers an amendment that did not happen. Without
+      // it a refused price change looks exactly like one still in flight. `by` is the
+      // requester, not the owner — on `not_order_owner` it is precisely who does not
+      // own the order — so it is resolved separately from `a`.
+      order.amendRejected = {
+        requestedPrice: dec(event.req_px),
+        requestedSize: dec(event.req_sz),
+        code: (event.code ?? "unspecified") as RejectCode,
+        message: event.why,
+        requestedBy: event.by !== undefined ? facts.accts?.[event.by] : undefined,
+        batchMs: facts.batchMs,
+      };
+      break;
     // ADR 0029 §6: kinds are open. An unrecognised one is ignored, not an error.
   }
 }

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -7,7 +7,8 @@
 // lets the server add transition kinds without changing the entity.
 
 import type {
-  Address, Order, OrderEvent, OrderEventKind, OrderStatus, PartialFill, RejectCode,
+  Address, Order, OrderEvent, OrderEventFill, OrderEventKind, OrderStatus, PartialFill,
+  RejectCode, TerminalStatus,
 } from "../types/public.js";
 import type { WireOrderEntity, WireOrderEvent, WireOrdersFrame } from "../types/wire.js";
 import { dec, endMsFromUs, usToMs } from "./units.js";
@@ -53,12 +54,11 @@ export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order
       ? created[event.o]
       : byId.get(event.id ?? "") ?? created.find((o) => o.id === event.id);
     if (!target) continue;
-    const fill = applyEvent(event, target, facts);
-    // Only kinds this version understands: an unrecognised one is ignored rather than
-    // handed on as an event a consumer cannot act on (ADR 0029 §6).
-    if (KNOWN_KINDS.has(event.k)) {
-      applied.push({ kind: event.k as OrderEventKind, order: target, batchMs, ...(fill && { fill }) });
-    }
+    // `undefined` means a kind this version does not know, which is ignored rather than
+    // handed on as an event a consumer cannot act on (ADR 0029 §6). The switch is the
+    // only list of what is recognised — a separate one could disagree with it.
+    const outcome = applyEvent(event, target, facts);
+    if (outcome) applied.push({ kind: event.k as OrderEventKind, order: target, batchMs, fill: outcome.fill });
   }
 
   // After the events, not before: an entity's own `new`/`reject` decides the
@@ -125,34 +125,33 @@ function applyTotals(event: WireOrderEvent, order: Order): void {
   order.effectivePrice = order.filledBase > 0n ? div(order.filledQuote, order.filledBase) : undefined;
 }
 
-const KNOWN_KINDS = new Set<string>([
-  "new", "reject", "fill", "cancel", "expire", "modify", "modify_reject",
-]);
-
-/** Apply one event, returning the fill it recorded when it was a fill. */
-function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): (PartialFill & { closedAs?: OrderStatus }) | undefined {
+/**
+ * Apply one event. `undefined` when the kind is not one this version knows; otherwise
+ * what the event contributed, which for a fill is the fill itself.
+ */
+function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): { fill?: OrderEventFill } | undefined {
   switch (event.k) {
     case "new":
       order.status = "active";
-      break;
+      return {};
     case "reject":
       order.status = "invalid";
       order.rejectReason = event.why;
-      break;
+      return {};
     case "cancel":
       order.status = "canceled";
       applyTotals(event, order);
-      break;
+      return {};
     case "expire":
       order.status = "expired";
       applyTotals(event, order);
-      break;
+      return {};
     case "modify": {
       order.price = dec(event.px);
       // `sz` is an unsigned magnitude, so the side comes from the order we hold.
       const sign = order.initialSize < 0n ? -1n : 1n;
       order.initialSize = sign * dec(event.sz);
-      break;
+      return {};
     }
     case "fill": {
       applyTotals(event, order);
@@ -179,7 +178,9 @@ function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): (Pa
       }
       // Present only on the fill that closed the order.
       if (event.st) order.status = event.st as OrderStatus;
-      return { ...fill, closedAs: event.st as OrderStatus | undefined };
+      // Copied rather than shared: the same object is in `order.fills`, and attaching a
+      // per-event field to it would leak the event into the order's fill history.
+      return { fill: { ...fill, closedAs: event.st as TerminalStatus | undefined } };
     }
     case "modify_reject":
       // The order is untouched: this answers an amendment that did not happen. Without
@@ -194,7 +195,8 @@ function applyEvent(event: WireOrderEvent, order: Order, facts: FrameFacts): (Pa
         requestedBy: event.by !== undefined ? facts.accts?.[event.by] : undefined,
         batchMs: facts.batchMs,
       };
-      break;
-    // ADR 0029 §6: kinds are open. An unrecognised one is ignored, not an error.
+      return {};
+    // ADR 0029 §6: kinds are open, so an unrecognised one falls through to
+    // `undefined` — applied to nothing, reported to nobody.
   }
 }

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -33,7 +33,14 @@ export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order
   const created = frame.orders.map((e) => decodeEntity(e, frame, batchMs, ctx.account));
 
   for (const event of frame.events) {
-    const target = event.o !== undefined ? created[event.o] : byId.get(event.id ?? "");
+    // `o` indexes this frame's entities and `id` names one resting from an earlier
+    // batch — but an event kind added later (ADR 0029 §6 reserves several) may name
+    // an entity from *this* frame by id, so try both before giving up. `created` is
+    // not in `byId` yet: entities are inserted after the events, so their own
+    // `new`/`reject` decides the status they land with.
+    const target = event.o !== undefined
+      ? created[event.o]
+      : byId.get(event.id ?? "") ?? created.find((o) => o.id === event.id);
     if (!target) continue;
     applyEvent(event, target, ctx.nowMs);
   }
@@ -62,8 +69,10 @@ function decodeEntity(e: WireOrderEntity, frame: WireOrdersFrame, batchMs: numbe
     status: "active",
     kind: (e.kind ?? "user_signed") as Order["kind"],
     nonce: e.n,
-    // A frame with no `accts` covers exactly one account, so every row is its.
-    bidder: (frame.accts && e.a !== undefined ? frame.accts[e.a] : account) as Address,
+    // A frame with no `accts` covers exactly one account, so every row is its. An
+    // index the table does not reach falls back the same way rather than becoming an
+    // `undefined` typed as an address.
+    bidder: (e.a !== undefined ? frame.accts?.[e.a] : undefined) ?? account,
     price: dec(e.px),
     initialSize,
     filledBase: 0n,
@@ -94,7 +103,9 @@ function applyTotals(event: WireOrderEvent, order: Order): void {
   order.filledBase = dec(event.tb);
   order.filledQuote = dec(event.tq);
   order.fee = dec(event.tf);
-  if (order.filledBase > 0n) order.effectivePrice = vwap(order.filledQuote, order.filledBase);
+  // Cleared, not skipped, when nothing is filled: a row reporting zero filled beside
+  // a fill price from before is worse than one with no fill price.
+  order.effectivePrice = order.filledBase > 0n ? vwap(order.filledQuote, order.filledBase) : undefined;
 }
 
 function applyEvent(event: WireOrderEvent, order: Order, nowMs: number): void {

--- a/ts-sdk/src/codec/orders-v2.ts
+++ b/ts-sdk/src/codec/orders-v2.ts
@@ -6,18 +6,19 @@
 // them and to orders already held. Status lives only in the events, which is what
 // lets the server add transition kinds without changing the entity.
 
-import type { Address, MarketId, MarketType, Order, OrderStatus, PartialFill } from "../types/public.js";
+import type { Address, Order, OrderStatus, PartialFill } from "../types/public.js";
 import type { WireOrderEntity, WireOrderEvent, WireOrdersFrame } from "../types/wire.js";
 import { dec, endMsFromUs, usToMs, WAD } from "./units.js";
 
 export interface OrdersFrameContext {
   /** The account the subscription is filtered to, used when the frame omits `accts`. */
   account: Address;
-  /** Market type for a book, when the markets list has loaded. */
-  marketType?: (book: MarketId) => MarketType | undefined;
   /** Receipt time (ms) stamped on this frame's fills — the wire carries none. */
   nowMs: number;
 }
+
+/** Volume-weighted price of a filled amount; zero base has no price. */
+const vwap = (quote: bigint, base: bigint) => (base > 0n ? (quote * WAD) / base : 0n);
 
 /**
  * Fold one frame into `byId`, in place.
@@ -27,7 +28,9 @@ export interface OrdersFrameContext {
  * never been on the wire, so there is nothing to display.
  */
 export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order>, ctx: OrdersFrameContext): void {
-  const created = frame.orders.map((e) => decodeEntity(e, frame, ctx));
+  // The book and the batch are frame constants: resolved once, not per entity.
+  const batchMs = usToMs(frame.batch);
+  const created = frame.orders.map((e) => decodeEntity(e, frame, batchMs, ctx.account));
 
   for (const event of frame.events) {
     const target = event.o !== undefined ? created[event.o] : byId.get(event.id ?? "");
@@ -42,16 +45,16 @@ export function applyOrdersFrame(frame: WireOrdersFrame, byId: Map<string, Order
   for (const order of created) byId.set(order.id, order);
 }
 
-function decodeEntity(e: WireOrderEntity, frame: WireOrdersFrame, ctx: OrdersFrameContext): Order {
+function decodeEntity(e: WireOrderEntity, frame: WireOrdersFrame, batchMs: number, account: Address): Order {
   const initialSize = dec(e.sz);
-  const batchMs = usToMs(frame.batch);
   return {
     id: e.id,
     txHash: e.tx,
-    // The frame names the book, so this is exact — v1 carried a token pair and
-    // left the id to be inferred from the markets list.
+    // The frame names the book, so this is exact rather than inferred. Whether
+    // that book is spot or perp is static market metadata, joined at read time by
+    // whoever needs it — freezing it here would strand every order decoded before
+    // the markets list loaded.
     orderbookId: frame.book,
-    marketType: ctx.marketType?.(frame.book),
     side: initialSize < 0n ? "sell" : "buy",
     orderType: e.type === "market" ? "market" : "limit",
     // Not on the entity: an order that rests is `active`, and the events below
@@ -60,7 +63,7 @@ function decodeEntity(e: WireOrderEntity, frame: WireOrdersFrame, ctx: OrdersFra
     kind: (e.kind ?? "user_signed") as Order["kind"],
     nonce: e.n,
     // A frame with no `accts` covers exactly one account, so every row is its.
-    bidder: (frame.accts && e.a !== undefined ? frame.accts[e.a] : ctx.account) as Address,
+    bidder: (frame.accts && e.a !== undefined ? frame.accts[e.a] : account) as Address,
     price: dec(e.px),
     initialSize,
     filledBase: 0n,
@@ -91,7 +94,7 @@ function applyTotals(event: WireOrderEvent, order: Order): void {
   order.filledBase = dec(event.tb);
   order.filledQuote = dec(event.tq);
   order.fee = dec(event.tf);
-  if (order.filledBase > 0n) order.effectivePrice = (order.filledQuote * WAD) / order.filledBase;
+  if (order.filledBase > 0n) order.effectivePrice = vwap(order.filledQuote, order.filledBase);
 }
 
 function applyEvent(event: WireOrderEvent, order: Order, nowMs: number): void {
@@ -124,7 +127,7 @@ function applyEvent(event: WireOrderEvent, order: Order, nowMs: number): void {
       // receipt time is the closest thing available.
       const base = dec(event.b);
       const quote = dec(event.q);
-      const fill: PartialFill = { base, quote, price: base > 0n ? (quote * WAD) / base : 0n, time: nowMs };
+      const fill: PartialFill = { base, quote, price: vwap(quote, base), time: nowMs };
       order.fills = [...order.fills, fill];
       // Present only on the fill that closed the order.
       if (event.st) order.status = event.st as OrderStatus;

--- a/ts-sdk/src/codec/units.ts
+++ b/ts-sdk/src/codec/units.ts
@@ -34,6 +34,21 @@ export function usToMsOpt(us: number | string | null | undefined): number | unde
   return us === null || us === undefined ? undefined : usToMs(us);
 }
 
+/**
+ * An order's TTL expiry: microseconds -> milliseconds, or undefined when it never
+ * expires.
+ *
+ * "Never" has two spellings on the wire. `pod_orders_v2` omits the field; REST
+ * sends the engine's `Timestamp::MAX` sentinel, a u128 that arrives as a 39-digit
+ * number no JS number can hold exactly. Anything past `Number.MAX_SAFE_INTEGER`
+ * micros — the year 2255 — is that sentinel rather than a TTL someone signed.
+ */
+export function endMsFromUs(us: number | string | null | undefined): number | undefined {
+  if (us === null || us === undefined) return undefined;
+  const n = typeof us === "string" ? Number(us) : us;
+  return Number.isFinite(n) && n <= Number.MAX_SAFE_INTEGER ? Math.trunc(n / 1000) : undefined;
+}
+
 /** Milliseconds -> microseconds (for request params that take micros). */
 export function msToUs(ms: number): number {
   return ms * 1000;

--- a/ts-sdk/src/codec/units.ts
+++ b/ts-sdk/src/codec/units.ts
@@ -46,7 +46,8 @@ export function usToMsOpt(us: number | string | null | undefined): number | unde
 export function endMsFromUs(us: number | string | null | undefined): number | undefined {
   if (us === null || us === undefined) return undefined;
   const n = typeof us === "string" ? Number(us) : us;
-  return Number.isFinite(n) && n <= Number.MAX_SAFE_INTEGER ? Math.trunc(n / 1000) : undefined;
+  // `NaN` and `Infinity` both fail this comparison, so it is the whole guard.
+  return n <= Number.MAX_SAFE_INTEGER ? usToMs(n) : undefined;
 }
 
 /** Milliseconds -> microseconds (for request params that take micros). */

--- a/ts-sdk/src/sync/orders.test.ts
+++ b/ts-sdk/src/sync/orders.test.ts
@@ -9,8 +9,9 @@
 
 import { describe, expect, it } from "vitest";
 
-import type { MarketId } from "../types/public.js";
-import { compareCursor } from "./orders.js";
+import type { Address, MarketId, OrderEvent } from "../types/public.js";
+import { OrderHistory, compareCursor } from "./orders.js";
+import type { SyncContext } from "./sources.js";
 
 const book = (n: number) => `0x${n.toString(16).padStart(64, "0")}` as MarketId;
 const B1 = book(1);
@@ -65,5 +66,102 @@ describe("compareCursor — already-delivered decisions", () => {
   it("accepts a later batch, drops an earlier one", () => {
     expect(delivered({ batch: 6, book: B1 }, { since: 5, sinceBook: B9 })).toBe(false);
     expect(delivered({ batch: 4, book: B9 }, { since: 5 })).toBe(true);
+  });
+});
+
+// --- the event channel's contracts, none of which the codec tests can see ---
+
+/**
+ * `OrderHistory` over a stub context: a REST page that resolves immediately and a
+ * websocket whose `subscribe` hands us the frame callback, so a test can deliver a
+ * frame the way the transport would.
+ */
+function harness() {
+  let deliver: ((result: unknown) => void) | undefined;
+  const ws = {
+    state: "open",
+    on: () => () => {},
+    subscribe: (_channel: string, _params: unknown, onMessage: (r: unknown) => void) => {
+      deliver = onMessage;
+      return { unsubscribe: () => {}, update: () => {}, resubscribe: () => {} };
+    },
+  };
+  const rest = {
+    orders: async () => ({ orders: [], nextCursor: null, totalCount: 0, solutionNow: 0 }),
+  };
+  const history = new OrderHistory(
+    { rest, ws, positionResyncMs: 0, marketResyncMs: 0 } as unknown as SyncContext,
+    "0xabc" as Address,
+  );
+  return { history, frame: (f: unknown) => deliver?.(f), delivered: () => deliver !== undefined };
+}
+
+const FRAME = {
+  book: `0x${"00".repeat(31)}07`,
+  batch: 1_000_000,
+  accts: ["0xabc"],
+  orders: [{ id: "0xnew", tx: "0xtx", a: 0, n: 1, px: "1", sz: "1" }],
+  events: [{ k: "new", o: 0 }],
+};
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("OrderHistory.onEvent", () => {
+  it("starts the stream on its own, without a snapshot subscriber", async () => {
+    const { history, frame, delivered } = harness();
+    const seen: OrderEvent[][] = [];
+    const off = history.onEvent((events) => seen.push(events));
+    await flush();
+
+    // The resource is ref-counted from `subscribe`/`ready`. Listening has to count too,
+    // or an event-only consumer waits forever — and today's app only worked because
+    // something else happened to hold the same instance.
+    expect(delivered(), "listening subscribed to the stream").toBe(true);
+    frame(FRAME);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.map((e) => e.kind)).toEqual(["new"]);
+    off();
+  });
+
+  it("emits after the snapshot, so a listener reads the state its events produced", async () => {
+    const { history, frame } = harness();
+    let orderCountWhenNotified: number | undefined;
+    const off = history.onEvent(() => { orderCountWhenNotified = history.get()?.length; });
+    await flush();
+
+    frame(FRAME);
+    // Emitting before `rebuild()` would show the listener the previous snapshot — the
+    // one without the order the event is about.
+    expect(orderCountWhenNotified).toBe(1);
+    off();
+  });
+
+  it("stops delivering once released, and survives a listener that throws", async () => {
+    const { history, frame } = harness();
+    const seen: string[] = [];
+    const offThrower = history.onEvent(() => { throw new Error("consumer bug"); });
+    const off = history.onEvent((events) => seen.push(...events.map((e) => e.kind)));
+    await flush();
+
+    // One listener's failure is its own, not the stream's.
+    expect(() => frame(FRAME)).not.toThrow();
+    expect(seen).toEqual(["new"]);
+
+    off();
+    frame({ ...FRAME, batch: 2_000_000, orders: [{ id: "0xtwo", tx: "0xtx", a: 0, n: 2, px: "1", sz: "1" }] });
+    expect(seen).toEqual(["new"]);
+    offThrower();
+  });
+
+  it("says nothing for the REST seed", async () => {
+    const { history } = harness();
+    const seen: OrderEvent[][] = [];
+    const off = history.onEvent((events) => seen.push(events));
+    await flush();
+
+    // The seed is history, not transitions. A consumer that had to filter it would be
+    // back to guessing which rows are new.
+    expect(seen).toEqual([]);
+    off();
   });
 });

--- a/ts-sdk/src/sync/orders.test.ts
+++ b/ts-sdk/src/sync/orders.test.ts
@@ -1,0 +1,69 @@
+// The stream position. A batch is delivered as one frame per book, so the position
+// is a pair — and the whole of the `pod_orders_v2` resume contract rests on an
+// absent book meaning "the whole batch", which sorts ABOVE every book in it.
+//
+// This is the mirror of `already_delivered` in `node/src/rpc/orders_v2.rs`:
+// `(frame_batch, frame_book) <= (since, since_book.unwrap_or(0xff…))`. If the two
+// sides disagree, the server re-sends frames the client has applied, and applying a
+// frame twice appends its fills twice.
+
+import { describe, expect, it } from "vitest";
+
+import type { MarketId } from "../types/public.js";
+import { compareCursor } from "./orders.js";
+
+const book = (n: number) => `0x${n.toString(16).padStart(64, "0")}` as MarketId;
+const B1 = book(1);
+const B9 = book(9);
+
+describe("compareCursor", () => {
+  it("orders by batch first", () => {
+    expect(compareCursor({ since: 1 }, { since: 2 })).toBeLessThan(0);
+    expect(compareCursor({ since: 2 }, { since: 1 })).toBeGreaterThan(0);
+    // A later batch wins whatever the books say.
+    expect(compareCursor({ since: 2, sinceBook: B1 }, { since: 1, sinceBook: B9 })).toBeGreaterThan(0);
+  });
+
+  it("orders by book within a batch", () => {
+    expect(compareCursor({ since: 5, sinceBook: B1 }, { since: 5, sinceBook: B9 })).toBeLessThan(0);
+    expect(compareCursor({ since: 5, sinceBook: B9 }, { since: 5, sinceBook: B1 })).toBe(1);
+    expect(compareCursor({ since: 5, sinceBook: B1 }, { since: 5, sinceBook: B1 })).toBe(0);
+  });
+
+  it("treats an absent book as the whole batch, above every book in it", () => {
+    // The bug this exists to prevent: a REST page settles whole batches, so its
+    // watermark has no book. Reading that as "book zero" made the next frame in the
+    // same batch look newer, and the cursor moved BACKWARDS from "all of batch 5" to
+    // "up to book 1 of batch 5" — after which the server re-sent the rest.
+    expect(compareCursor({ since: 5, sinceBook: B9 }, { since: 5 })).toBeLessThan(0);
+    expect(compareCursor({ since: 5 }, { since: 5, sinceBook: B9 })).toBeGreaterThan(0);
+    expect(compareCursor({ since: 5 }, { since: 5 })).toBe(0);
+  });
+
+  it("treats a missing batch as the beginning", () => {
+    // A fresh cursor, before any page or frame has landed.
+    expect(compareCursor({}, { since: 1 })).toBeLessThan(0);
+    expect(compareCursor({ since: 1, sinceBook: B1 }, {})).toBeGreaterThan(0);
+  });
+});
+
+describe("compareCursor — already-delivered decisions", () => {
+  /** What `onFrame` asks: is this frame at or behind where we already are? */
+  const delivered = (frame: { batch: number; book: MarketId }, cursor: Parameters<typeof compareCursor>[1]) =>
+    compareCursor({ since: frame.batch, sinceBook: frame.book }, cursor) <= 0;
+
+  it("drops a frame inside a batch a REST page already settled", () => {
+    expect(delivered({ batch: 5, book: B1 }, { since: 5 })).toBe(true);
+    expect(delivered({ batch: 5, book: B9 }, { since: 5 })).toBe(true);
+  });
+
+  it("accepts the rest of a partly delivered batch, and drops what it already has", () => {
+    expect(delivered({ batch: 5, book: B1 }, { since: 5, sinceBook: B1 })).toBe(true);
+    expect(delivered({ batch: 5, book: B9 }, { since: 5, sinceBook: B1 })).toBe(false);
+  });
+
+  it("accepts a later batch, drops an earlier one", () => {
+    expect(delivered({ batch: 6, book: B1 }, { since: 5, sinceBook: B9 })).toBe(false);
+    expect(delivered({ batch: 4, book: B9 }, { since: 5 })).toBe(true);
+  });
+});

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -231,7 +231,7 @@ export class OrderHistory implements SeriesResource<Order> {
     const at: SubParams = { since: frame.batch, sinceBook: frame.book };
     if (compareCursor(at, this.cursor) <= 0) return;
 
-    applyOrdersFrame(frame, this.byId, { account: this.account, nowMs: Date.now() });
+    applyOrdersFrame(frame, this.byId, { account: this.account });
     // A socket-level reconnect resubscribes from whatever is stored here.
     this.cursor = at;
     this.sub?.update(at);

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -193,6 +193,15 @@ export class OrderHistory implements SeriesResource<Order> {
       this.sub?.resubscribe();
       return;
     }
+    // The slow path, and the one that answers "what if we fell behind the server's
+    // replay buffer": `eth_subscribe` rejects a `since` older than what the buffer
+    // retains, and the prescribed recovery is to backfill over REST and resubscribe.
+    // That is what this is. `fetchFirstPage` also *replaces the cursor* with the
+    // page's watermark, so the position that was too old is gone by the first retry
+    // and the resubscribe is accepted with no gap — the server replays from the page
+    // forward. Dropping the cursor below is the backstop for when even that fresh
+    // watermark is refused (the indexer further behind than the buffer retains):
+    // live-only resubscribe, trading the unreplayable window for a working stream.
     this.subRetries++;
     const delay = Math.min(30_000, 500 * 2 ** (this.subRetries - 1));
     if (this.retryTimer) clearTimeout(this.retryTimer);

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -200,7 +200,13 @@ export class OrderHistory implements SeriesResource<Order> {
     let arr = [...this.byId.values()];
     if (this.query.status) arr = arr.filter((o) => o.status === this.query.status);
     if (this.query.orderbookId) arr = arr.filter((o) => o.orderbookId === this.query.orderbookId);
-    arr.sort((a, b) => b.deadlineMs - a.deadlineMs || b.nonce - a.nonce);
+    // Newest first by when the order became real. Inclusion time is the key both
+    // sources report — REST sends it alongside the signed deadline, and a frame's
+    // batch *is* it — so a REST row and a streamed row sort against each other.
+    // A signed order not yet in a batch has neither and sorts to the top, which is
+    // where the newest thing belongs.
+    const at = (o: Order) => o.includedMs ?? o.deadlineMs ?? Number.MAX_SAFE_INTEGER;
+    arr.sort((a, b) => at(b) - at(a) || b.nonce - a.nonce);
     this.handle.set(arr);
   }
 }

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -5,15 +5,15 @@
 // Reconnect: on every (re)connect we re-seed the first page (authoritative open
 // orders) and refresh the cursor from its watermark; the WS auto-resubscribes,
 // and if the cursor is too old (down too long) `onError` re-seeds and
-// resubscribes. A server-initiated close is not the same as a rejection: the
-// transport has already advanced the cursor to the server's watermark, so
-// resuming from one is a bare `resubscribe()` with no re-seed.
+// resubscribes. A server-initiated close is not the same as a rejection: it
+// reports where delivery stopped, so resuming from one is a bare `resubscribe()`
+// with no re-seed.
 
-import type { Address, Hash, MarketId, MarketType, Order, OrdersQuery } from "../types/public.js";
+import type { Address, Order, OrdersQuery } from "../types/public.js";
 import type { WireOrdersFrame } from "../types/wire.js";
 import { applyOrdersFrame } from "../codec/orders-v2.js";
 import { BaseResource, type ResourceHandle } from "../stores/resource.js";
-import { PodSubscriptionClosedError, type Subscription } from "../transport/ws.js";
+import { PodSubscriptionClosedError, type SubParams, type Subscription } from "../transport/ws.js";
 import type { SeriesResource } from "./candles.js";
 import type { SyncContext } from "./sources.js";
 
@@ -25,28 +25,36 @@ import type { SyncContext } from "./sources.js";
  */
 const FAST_RESUMES_BEFORE_RESEED = 3;
 
+/**
+ * Re-seed attempts that keep the cursor before we conclude the cursor is what the
+ * server is rejecting, drop it, and settle for streaming live.
+ */
+const RETRIES_BEFORE_DROPPING_CURSOR = 2;
+
 export class OrderHistory implements SeriesResource<Order> {
   private readonly base: BaseResource<Order[]>;
   private handle: ResourceHandle<Order[]> | undefined;
   private readonly byId = new Map<string, Order>();
   private nextCursor: string | null = null;
   private sub: Subscription | undefined;
-  private watermarkUs = 0;
   private alive = false;
   private _hasMore = true;
   private _loading = false;
   private subRetries = 0;
   private fastResumes = 0;
   private retryTimer?: ReturnType<typeof setTimeout>;
-  /** The last frame accepted: `since` plus the book that completes it. */
-  private cursorBook: Hash | undefined;
+  /**
+   * Where the stream is: the last frame accepted, as the `(batch, book)` pair the
+   * channel resumes from. Replaced whole rather than patched half at a time —
+   * `sinceBook` names a book *within* `since`, so the two are one fact and a
+   * mismatched pair asks the server to skip books we never saw.
+   */
+  private cursor: SubParams = { since: 0 };
 
   constructor(
     private readonly ctx: SyncContext,
     private readonly account: Address,
     private readonly query: OrdersQuery = {},
-    /** The market type for a book, when the markets list has loaded. */
-    private readonly marketType?: (book: MarketId) => MarketType | undefined,
   ) {
     this.base = new BaseResource<Order[]>((h) => {
       this.handle = h;
@@ -104,13 +112,10 @@ export class OrderHistory implements SeriesResource<Order> {
       // Only ever forward. The indexer can be behind the stream, and resuming from
       // a point already applied re-delivers frames — harmless for entities and
       // modifications, which carry absolute values, but a replayed fill would be
-      // appended to `fills` a second time. A page settles whole batches, so a
-      // watermark taken from one retires the book half of the cursor.
+      // appended to `fills` a second time. A page settles whole batches, so its
+      // watermark carries no book.
       const pageUs = page.solutionNow * 1000;
-      if (pageUs > this.watermarkUs) {
-        this.watermarkUs = pageUs;
-        this.cursorBook = undefined;
-      }
+      if (pageUs > (this.cursor.since ?? 0)) this.cursor = { since: pageUs };
       this.rebuild();
       return true;
     } catch (e) {
@@ -125,13 +130,12 @@ export class OrderHistory implements SeriesResource<Order> {
       if (!this.sub) {
         this.sub = this.ctx.ws.subscribe(
           "pod_orders_v2",
-          { account: this.account, since: this.watermarkUs, sinceBook: this.cursorBook },
+          { account: this.account, ...this.cursor },
           (r) => this.onFrame(r),
           (e) => this.onSubError(e),
         );
       } else {
-        // Refresh for the next reconnect.
-        this.sub.update({ since: this.watermarkUs, sinceBook: this.cursorBook });
+        this.sub.update(this.cursor); // refresh for the next reconnect
       }
     });
   }
@@ -140,18 +144,22 @@ export class OrderHistory implements SeriesResource<Order> {
    * The subscription is not running: `eth_subscribe` was rejected, or the server
    * closed it.
    *
-   * A resumable close needs neither a re-seed nor a delay — the transport has
-   * already moved the cursor to the server's watermark, so resubscribing delivers
-   * exactly the frames we never got. Everything else (a rejection, a server bug,
-   * or closes that keep coming) takes the slow path: backed off and capped, so a
-   * server that keeps refusing cannot spin this into a tight re-seed loop, and
-   * after a couple of failures the cursor is dropped (the likely culprit) to just
-   * stream live. Both counters reset once live data flows (`onFrame`).
+   * A resumable close needs neither a re-seed nor a delay: the server reports where
+   * it stopped, so resubscribing from that delivers exactly the frames we never got.
+   * Everything else (a rejection, a server bug, or closes that keep coming) takes
+   * the slow path: backed off and capped, so a server that keeps refusing cannot
+   * spin this into a tight re-seed loop, and eventually the cursor is dropped (the
+   * likely culprit) to just stream live. Both counters reset once live data flows
+   * (`onFrame`).
    */
   private onSubError(err: unknown): void {
     if (!this.alive) return;
     if (err instanceof PodSubscriptionClosedError && err.resumable && this.fastResumes < FAST_RESUMES_BEFORE_RESEED) {
       this.fastResumes++;
+      // The server's watermark beats ours — it knows which frames it managed to
+      // hand over — and taking it here keeps `cursor` the one place the position
+      // lives, rather than leaving it to the copy the transport advanced.
+      if (err.resumeSince !== undefined) this.cursor = { since: err.resumeSince, sinceBook: err.resumeSinceBook };
       this.sub?.resubscribe();
       return;
     }
@@ -161,11 +169,8 @@ export class OrderHistory implements SeriesResource<Order> {
     this.retryTimer = setTimeout(() => {
       void this.fetchFirstPage().then((ok) => {
         if (!ok || !this.alive) return;
-        const tooOld = this.subRetries > 2;
-        this.sub?.update({
-          since: tooOld ? undefined : this.watermarkUs,
-          sinceBook: tooOld ? undefined : this.cursorBook,
-        });
+        const tooOld = this.subRetries > RETRIES_BEFORE_DROPPING_CURSOR;
+        this.sub?.update(tooOld ? { since: undefined, sinceBook: undefined } : this.cursor);
         this.sub?.resubscribe();
       });
     }, delay);
@@ -177,30 +182,21 @@ export class OrderHistory implements SeriesResource<Order> {
     this.subRetries = 0;
     this.fastResumes = 0;
     const frame = result as WireOrdersFrame;
-    if (!frame || typeof frame !== "object" || !Array.isArray(frame.events)) return;
+    if (!frame || !Array.isArray(frame.orders) || !Array.isArray(frame.events)) return;
 
-    applyOrdersFrame(frame, this.byId, {
-      account: this.account,
-      marketType: this.marketType,
-      nowMs: Date.now(),
-    });
-    // Advance both halves together. A batch is delivered as one frame per book,
-    // so this pair — not the batch alone — is where the stream actually is, and a
-    // socket-level reconnect resubscribes from whatever is stored here. Never
-    // backwards: a resumed subscription replays older batches, which must not
-    // undo the position we already reached.
-    if (frame.batch >= this.watermarkUs) {
-      this.watermarkUs = frame.batch;
-      this.cursorBook = frame.book;
-      this.sub?.update({ since: frame.batch, sinceBook: frame.book });
+    applyOrdersFrame(frame, this.byId, { account: this.account, nowMs: Date.now() });
+    // A socket-level reconnect resubscribes from whatever is stored here, so the
+    // pair advances per frame — never backwards, since a resumed subscription
+    // replays older batches and must not undo the position we already reached.
+    if (frame.batch >= (this.cursor.since ?? 0)) {
+      this.cursor = { since: frame.batch, sinceBook: frame.book };
+      this.sub?.update(this.cursor);
     }
     this.rebuild();
   }
 
   private rebuild(): void {
     if (!this.handle) return;
-    // Orders arrive with their book named by the frame, so `orderbookId` is set
-    // from the start — nothing to resolve here.
     let arr = [...this.byId.values()];
     if (this.query.status) arr = arr.filter((o) => o.status === this.query.status);
     if (this.query.orderbookId) arr = arr.filter((o) => o.orderbookId === this.query.orderbookId);

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -114,13 +114,16 @@ export class OrderHistory implements SeriesResource<Order> {
    * a snapshot cannot express: two fills in one batch are one state change, and a
    * refused amendment is none at all. Nothing is emitted for the REST seed, so a
    * consumer never has to filter out a backlog of history as if it were live.
-   *
-   * Emitted after the snapshot is published, so a listener reading the resource sees
-   * the state the events produced.
    */
   onEvent(listener: (events: OrderEvent[]) => void): () => void {
     this.eventListeners.add(listener);
-    return () => { this.eventListeners.delete(listener); };
+    // Listening starts the stream, like subscribing does. The resource is ref-counted
+    // from `subscribe`/`ready` alone, so without holding one an event-only consumer
+    // would wait forever — and would fall silent the moment the last snapshot
+    // subscriber left, since teardown drops the websocket subscription and leaves the
+    // listeners registered.
+    const release = this.base.subscribe(() => {});
+    return () => { this.eventListeners.delete(listener); release(); };
   }
 
   setWindow(): void { /* order history pages by cursor, not by time window */ }
@@ -259,8 +262,8 @@ export class OrderHistory implements SeriesResource<Order> {
     this.cursor = at;
     this.sub?.update(at);
     this.rebuild();
-    // After the snapshot: a listener that reads the resource in response to an event
-    // must see the state that event produced, not the state before it.
+    // Strictly after `rebuild()`: a listener that reads the resource in response to an
+    // event must see the state that event produced, not the state before it.
     if (events.length) {
       for (const listener of this.eventListeners) {
         try { listener(events); } catch { /* a listener's failure is not the stream's */ }

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -9,7 +9,7 @@
 // reports where delivery stopped, so resuming from one is a bare `resubscribe()`
 // with no re-seed.
 
-import type { Address, MarketId, Order, OrdersQuery } from "../types/public.js";
+import type { Address, MarketId, Order, OrderEvent, OrdersQuery } from "../types/public.js";
 import type { WireOrdersFrame } from "../types/wire.js";
 import { applyOrdersFrame } from "../codec/orders-v2.js";
 import { BaseResource, type ResourceHandle } from "../stores/resource.js";
@@ -68,6 +68,7 @@ export class OrderHistory implements SeriesResource<Order> {
   private subRetries = 0;
   private fastResumes = 0;
   private retryTimer?: ReturnType<typeof setTimeout>;
+  private readonly eventListeners = new Set<(events: OrderEvent[]) => void>();
   /**
    * Where the stream is: the last frame accepted, as the `(batch, book)` pair the
    * channel resumes from. Replaced whole rather than patched half at a time —
@@ -104,6 +105,23 @@ export class OrderHistory implements SeriesResource<Order> {
   hasMore(): boolean { return this._hasMore; }
   loading(): boolean { return this._loading; }
   destroy(): void { this.base.destroy(); }
+
+  /**
+   * Observe the transitions the stream reports, as they arrive — a frame at a time, in
+   * the order the engine caused them.
+   *
+   * The snapshot (`get`/`subscribe`) is what to render; this is what *happened*, which
+   * a snapshot cannot express: two fills in one batch are one state change, and a
+   * refused amendment is none at all. Nothing is emitted for the REST seed, so a
+   * consumer never has to filter out a backlog of history as if it were live.
+   *
+   * Emitted after the snapshot is published, so a listener reading the resource sees
+   * the state the events produced.
+   */
+  onEvent(listener: (events: OrderEvent[]) => void): () => void {
+    this.eventListeners.add(listener);
+    return () => { this.eventListeners.delete(listener); };
+  }
 
   setWindow(): void { /* order history pages by cursor, not by time window */ }
 
@@ -236,11 +254,18 @@ export class OrderHistory implements SeriesResource<Order> {
     const at: SubParams = { since: frame.batch, sinceBook: frame.book };
     if (compareCursor(at, this.cursor) <= 0) return;
 
-    applyOrdersFrame(frame, this.byId, { account: this.account });
+    const events = applyOrdersFrame(frame, this.byId, { account: this.account });
     // A socket-level reconnect resubscribes from whatever is stored here.
     this.cursor = at;
     this.sub?.update(at);
     this.rebuild();
+    // After the snapshot: a listener that reads the resource in response to an event
+    // must see the state that event produced, not the state before it.
+    if (events.length) {
+      for (const listener of this.eventListeners) {
+        try { listener(events); } catch { /* a listener's failure is not the stream's */ }
+      }
+    }
   }
 
   private rebuild(): void {

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -1,19 +1,29 @@
 // OrderHistory: a SeriesResource<Order> seeded from the warm first page, kept
-// live by the pod_orders stream (bidder-filtered, `since`-resumed, all update
-// variants incl. `modified`), and paged backwards by cursor for deep history.
+// live by the pod_orders_v2 stream (bidder-filtered, resumed from a (batch, book)
+// cursor), and paged backwards by cursor for deep history.
 //
 // Reconnect: on every (re)connect we re-seed the first page (authoritative open
-// orders) and refresh `since` from its watermark; the WS auto-resubscribes, and
-// if `since` is too old (down too long) `onError` re-seeds and resubscribes.
+// orders) and refresh the cursor from its watermark; the WS auto-resubscribes,
+// and if the cursor is too old (down too long) `onError` re-seeds and
+// resubscribes. A server-initiated close is not the same as a rejection: the
+// transport has already advanced the cursor to the server's watermark, so
+// resuming from one is a bare `resubscribe()` with no re-seed.
 
-import type { Address, MarketId, Order, OrderStatus, OrdersQuery } from "../types/public.js";
-import type { WireOrderUpdate } from "../types/wire.js";
-import { dec, WAD } from "../codec/units.js";
-import { decodeOrder } from "../codec/decode.js";
+import type { Address, Hash, MarketId, MarketType, Order, OrdersQuery } from "../types/public.js";
+import type { WireOrdersFrame } from "../types/wire.js";
+import { applyOrdersFrame } from "../codec/orders-v2.js";
 import { BaseResource, type ResourceHandle } from "../stores/resource.js";
-import type { Subscription } from "../transport/ws.js";
+import { PodSubscriptionClosedError, type Subscription } from "../transport/ws.js";
 import type { SeriesResource } from "./candles.js";
 import type { SyncContext } from "./sources.js";
+
+/**
+ * Consecutive server closes we resume from before falling back to the re-seed
+ * path. A lagged close is recoverable by resubscribing, so the fast path is the
+ * right default — but a stream that keeps closing is one we are not keeping up
+ * with, and re-seeding beats replaying a growing backlog on every attempt.
+ */
+const FAST_RESUMES_BEFORE_RESEED = 3;
 
 export class OrderHistory implements SeriesResource<Order> {
   private readonly base: BaseResource<Order[]>;
@@ -26,14 +36,17 @@ export class OrderHistory implements SeriesResource<Order> {
   private _hasMore = true;
   private _loading = false;
   private subRetries = 0;
+  private fastResumes = 0;
   private retryTimer?: ReturnType<typeof setTimeout>;
+  /** The last frame accepted: `since` plus the book that completes it. */
+  private cursorBook: Hash | undefined;
 
   constructor(
     private readonly ctx: SyncContext,
     private readonly account: Address,
     private readonly query: OrdersQuery = {},
-    /** Maps a WS order's token pair to its orderbook id (see rebuild). */
-    private readonly resolveOrderbookId?: (pair: { base: Address; quote: Address }) => MarketId | undefined,
+    /** The market type for a book, when the markets list has loaded. */
+    private readonly marketType?: (book: MarketId) => MarketType | undefined,
   ) {
     this.base = new BaseResource<Order[]>((h) => {
       this.handle = h;
@@ -88,7 +101,16 @@ export class OrderHistory implements SeriesResource<Order> {
       for (const o of page.orders) this.byId.set(o.id, o);
       this.nextCursor = page.nextCursor;
       this._hasMore = page.nextCursor !== null;
-      this.watermarkUs = page.solutionNow * 1000;
+      // Only ever forward. The indexer can be behind the stream, and resuming from
+      // a point already applied re-delivers frames — harmless for entities and
+      // modifications, which carry absolute values, but a replayed fill would be
+      // appended to `fills` a second time. A page settles whole batches, so a
+      // watermark taken from one retires the book half of the cursor.
+      const pageUs = page.solutionNow * 1000;
+      if (pageUs > this.watermarkUs) {
+        this.watermarkUs = pageUs;
+        this.cursorBook = undefined;
+      }
       this.rebuild();
       return true;
     } catch (e) {
@@ -102,100 +124,83 @@ export class OrderHistory implements SeriesResource<Order> {
       if (!ok || !this.alive) return;
       if (!this.sub) {
         this.sub = this.ctx.ws.subscribe(
-          "pod_orders",
-          { account: this.account, since: this.watermarkUs },
-          (r) => this.onUpdates(r),
-          () => this.onSubError(),
+          "pod_orders_v2",
+          { account: this.account, since: this.watermarkUs, sinceBook: this.cursorBook },
+          (r) => this.onFrame(r),
+          (e) => this.onSubError(e),
         );
       } else {
-        this.sub.update({ since: this.watermarkUs }); // refresh for the next reconnect
+        // Refresh for the next reconnect.
+        this.sub.update({ since: this.watermarkUs, sinceBook: this.cursorBook });
       }
     });
   }
 
   /**
-   * Subscription rejected — re-seed then resubscribe. Backed off (and capped),
-   * so a server that keeps rejecting can't spin this into a tight re-seed /
-   * resubscribe loop. After a couple of failures we drop `since` (the likely
-   * culprit) and just stream live. Reset once live data flows (`onUpdates`).
+   * The subscription is not running: `eth_subscribe` was rejected, or the server
+   * closed it.
+   *
+   * A resumable close needs neither a re-seed nor a delay — the transport has
+   * already moved the cursor to the server's watermark, so resubscribing delivers
+   * exactly the frames we never got. Everything else (a rejection, a server bug,
+   * or closes that keep coming) takes the slow path: backed off and capped, so a
+   * server that keeps refusing cannot spin this into a tight re-seed loop, and
+   * after a couple of failures the cursor is dropped (the likely culprit) to just
+   * stream live. Both counters reset once live data flows (`onFrame`).
    */
-  private onSubError(): void {
+  private onSubError(err: unknown): void {
     if (!this.alive) return;
+    if (err instanceof PodSubscriptionClosedError && err.resumable && this.fastResumes < FAST_RESUMES_BEFORE_RESEED) {
+      this.fastResumes++;
+      this.sub?.resubscribe();
+      return;
+    }
     this.subRetries++;
     const delay = Math.min(30_000, 500 * 2 ** (this.subRetries - 1));
     if (this.retryTimer) clearTimeout(this.retryTimer);
     this.retryTimer = setTimeout(() => {
       void this.fetchFirstPage().then((ok) => {
         if (!ok || !this.alive) return;
-        this.sub?.update({ since: this.subRetries > 2 ? undefined : this.watermarkUs });
+        const tooOld = this.subRetries > 2;
+        this.sub?.update({
+          since: tooOld ? undefined : this.watermarkUs,
+          sinceBook: tooOld ? undefined : this.cursorBook,
+        });
         this.sub?.resubscribe();
       });
     }, delay);
   }
 
-  private onUpdates(result: unknown): void {
-    this.subRetries = 0; // live data flowing → subscription is healthy
-    const updates = (Array.isArray(result) ? result : [result]) as WireOrderUpdate[];
-    for (const u of updates) this.applyUpdate(u);
-    this.rebuild();
-  }
+  /** One frame: everything that happened to one book in one auction batch. */
+  private onFrame(result: unknown): void {
+    // Live data flowing → the subscription is healthy on both paths.
+    this.subRetries = 0;
+    this.fastResumes = 0;
+    const frame = result as WireOrdersFrame;
+    if (!frame || typeof frame !== "object" || !Array.isArray(frame.events)) return;
 
-  private applyUpdate(u: WireOrderUpdate): void {
-    switch (u.type) {
-      case "new":
-      case "invalid": {
-        const o = decodeOrder(u);
-        this.byId.set(o.id, o);
-        break;
-      }
-      case "fill": {
-        const e = this.byId.get(u.order_id);
-        if (e) {
-          e.filledBase = dec(u.filled_base_amount);
-          e.filledQuote = dec(u.filled_quote_amount);
-          e.fee = dec(u.fee);
-          e.status = u.status as OrderStatus;
-          if (u.effective_price != null) e.effectivePrice = dec(u.effective_price);
-          // Keep the per-fill breakdown live too. The push carries this fill's
-          // base/quote delta but no timestamp — receipt time is close enough.
-          const base = dec(u.base_amount);
-          const quote = dec(u.quote_amount);
-          e.fills = [...e.fills, { base, quote, price: base > 0n ? (quote * WAD) / base : 0n, time: Date.now() }];
-        }
-        break;
-      }
-      case "modified": {
-        const e = this.byId.get(u.order_id);
-        if (e) {
-          e.price = dec(u.new_price);
-          const sign = e.initialSize < 0n ? -1n : 1n;
-          e.initialSize = sign * dec(u.new_size); // new_size is an unsigned magnitude
-        }
-        break;
-      }
-      case "expired": {
-        const e = this.byId.get(u.order_id);
-        if (e) e.status = "expired";
-        break;
-      }
-      case "canceled": {
-        const e = this.byId.get(u.order_id);
-        if (e) e.status = "canceled";
-        break;
-      }
+    applyOrdersFrame(frame, this.byId, {
+      account: this.account,
+      marketType: this.marketType,
+      nowMs: Date.now(),
+    });
+    // Advance both halves together. A batch is delivered as one frame per book,
+    // so this pair — not the batch alone — is where the stream actually is, and a
+    // socket-level reconnect resubscribes from whatever is stored here. Never
+    // backwards: a resumed subscription replays older batches, which must not
+    // undo the position we already reached.
+    if (frame.batch >= this.watermarkUs) {
+      this.watermarkUs = frame.batch;
+      this.cursorBook = frame.book;
+      this.sub?.update({ since: frame.batch, sinceBook: frame.book });
     }
+    this.rebuild();
   }
 
   private rebuild(): void {
     if (!this.handle) return;
-    // WS stream orders carry a token `pair` instead of orderbook_id — resolve
-    // it here so consumers can always filter by market. Retried every rebuild,
-    // so orders that streamed in before the markets list loaded still resolve.
-    if (this.resolveOrderbookId) {
-      for (const o of this.byId.values()) {
-        if (o.orderbookId === undefined && o.pair) o.orderbookId = this.resolveOrderbookId(o.pair);
-      }
-    }
+    // Orders arrive with their book named by the frame, so `orderbookId` is set
+    // from the start — nothing to resolve here.
     let arr = [...this.byId.values()];
     if (this.query.status) arr = arr.filter((o) => o.status === this.query.status);
     if (this.query.orderbookId) arr = arr.filter((o) => o.orderbookId === this.query.orderbookId);

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -9,7 +9,7 @@
 // reports where delivery stopped, so resuming from one is a bare `resubscribe()`
 // with no re-seed.
 
-import type { Address, Order, OrdersQuery } from "../types/public.js";
+import type { Address, MarketId, Order, OrdersQuery } from "../types/public.js";
 import type { WireOrdersFrame } from "../types/wire.js";
 import { applyOrdersFrame } from "../codec/orders-v2.js";
 import { BaseResource, type ResourceHandle } from "../stores/resource.js";
@@ -30,6 +30,29 @@ const FAST_RESUMES_BEFORE_RESEED = 3;
  * server is rejecting, drop it, and settle for streaming live.
  */
 const RETRIES_BEFORE_DROPPING_CURSOR = 2;
+
+/** The largest book id, which is what an absent `sinceBook` means. */
+const WHOLE_BATCH = `0x${"ff".repeat(32)}` as MarketId;
+
+/**
+ * Order two positions in the stream, the way the server does.
+ *
+ * A batch is delivered as one frame per book, so a position is the pair
+ * `(batch, book)` — and an absent book means the whole batch, which sorts *above*
+ * every book in it. This mirrors `already_delivered` in
+ * `node/src/rpc/orders_v2.rs`: `(frame_batch, frame_book) <= (since,
+ * since_book.unwrap_or(0xff…))`. Getting the absent case wrong turns "all of batch
+ * N" into "up to book B of batch N", which asks the server to re-send the rest.
+ *
+ * Book ids are fixed-width lowercase hex, so comparing them as strings is
+ * comparing their bytes.
+ */
+export function compareCursor(a: SubParams, b: SubParams): number {
+  const [ab, bb] = [a.since ?? 0, b.since ?? 0];
+  if (ab !== bb) return ab < bb ? -1 : 1;
+  const [abook, bbook] = [a.sinceBook ?? WHOLE_BATCH, b.sinceBook ?? WHOLE_BATCH];
+  return abook === bbook ? 0 : abook < bbook ? -1 : 1;
+}
 
 export class OrderHistory implements SeriesResource<Order> {
   private readonly base: BaseResource<Order[]>;
@@ -109,13 +132,11 @@ export class OrderHistory implements SeriesResource<Order> {
       for (const o of page.orders) this.byId.set(o.id, o);
       this.nextCursor = page.nextCursor;
       this._hasMore = page.nextCursor !== null;
-      // Only ever forward. The indexer can be behind the stream, and resuming from
-      // a point already applied re-delivers frames — harmless for entities and
-      // modifications, which carry absolute values, but a replayed fill would be
-      // appended to `fills` a second time. A page settles whole batches, so its
-      // watermark carries no book.
-      const pageUs = page.solutionNow * 1000;
-      if (pageUs > (this.cursor.since ?? 0)) this.cursor = { since: pageUs };
+      // Only ever forward, and a page settles whole batches, so its watermark
+      // carries no book — which makes it *ahead* of a stream position in the same
+      // batch, not equal to it.
+      const settled: SubParams = { since: page.solutionNow * 1000 };
+      if (compareCursor(settled, this.cursor) > 0) this.cursor = settled;
       this.rebuild();
       return true;
     } catch (e) {
@@ -146,20 +167,29 @@ export class OrderHistory implements SeriesResource<Order> {
    *
    * A resumable close needs neither a re-seed nor a delay: the server reports where
    * it stopped, so resubscribing from that delivers exactly the frames we never got.
-   * Everything else (a rejection, a server bug, or closes that keep coming) takes
-   * the slow path: backed off and capped, so a server that keeps refusing cannot
-   * spin this into a tight re-seed loop, and eventually the cursor is dropped (the
-   * likely culprit) to just stream live. Both counters reset once live data flows
-   * (`onFrame`).
+   * That fast path is only taken while the socket is actually open — `resubscribe()`
+   * is a no-op otherwise, which would spend the budget without an attempt and leave
+   * nothing scheduled, and `-32021` (node shutting down) arrives exactly as the
+   * socket goes away.
+   *
+   * Everything else (a rejection, a server bug, a close with the socket already
+   * gone, or closes that keep coming) takes the slow path: backed off and capped, so
+   * a server that keeps refusing cannot spin this into a tight re-seed loop, and
+   * eventually the cursor is dropped (the likely culprit) to just stream live. Both
+   * counters reset once live data flows (`onFrame`).
    */
   private onSubError(err: unknown): void {
     if (!this.alive) return;
-    if (err instanceof PodSubscriptionClosedError && err.resumable && this.fastResumes < FAST_RESUMES_BEFORE_RESEED) {
+    const canFastResume = err instanceof PodSubscriptionClosedError && err.resumable
+      && this.fastResumes < FAST_RESUMES_BEFORE_RESEED && this.ctx.ws.state === "open";
+    if (canFastResume) {
       this.fastResumes++;
-      // The server's watermark beats ours — it knows which frames it managed to
-      // hand over — and taking it here keeps `cursor` the one place the position
-      // lives, rather than leaving it to the copy the transport advanced.
-      if (err.resumeSince !== undefined) this.cursor = { since: err.resumeSince, sinceBook: err.resumeSinceBook };
+      // Adopt the server's watermark only when it is ahead of ours: it knows which
+      // frames it handed over, but a re-seed may already have carried us past it,
+      // and rewinding would re-deliver frames we have applied.
+      const closed = err as PodSubscriptionClosedError;
+      const reported: SubParams = { since: closed.resumeSince, sinceBook: closed.resumeSinceBook };
+      if (closed.resumeSince !== undefined && compareCursor(reported, this.cursor) > 0) this.cursor = reported;
       this.sub?.resubscribe();
       return;
     }
@@ -184,14 +214,18 @@ export class OrderHistory implements SeriesResource<Order> {
     const frame = result as WireOrdersFrame;
     if (!frame || !Array.isArray(frame.orders) || !Array.isArray(frame.events)) return;
 
+    // Drop what we already hold. Applying a frame is not idempotent — a fill event
+    // appends to `order.fills`, and re-creating an entity resets its totals — and
+    // re-delivery is designed in: a resumed subscription replays from a cursor, and
+    // the replay boundary is a whole batch. Same predicate as the server's
+    // `already_delivered`, so client and server agree on what "already sent" means.
+    const at: SubParams = { since: frame.batch, sinceBook: frame.book };
+    if (compareCursor(at, this.cursor) <= 0) return;
+
     applyOrdersFrame(frame, this.byId, { account: this.account, nowMs: Date.now() });
-    // A socket-level reconnect resubscribes from whatever is stored here, so the
-    // pair advances per frame — never backwards, since a resumed subscription
-    // replays older batches and must not undo the position we already reached.
-    if (frame.batch >= (this.cursor.since ?? 0)) {
-      this.cursor = { since: frame.batch, sinceBook: frame.book };
-      this.sub?.update(this.cursor);
-    }
+    // A socket-level reconnect resubscribes from whatever is stored here.
+    this.cursor = at;
+    this.sub?.update(at);
     this.rebuild();
   }
 
@@ -202,10 +236,11 @@ export class OrderHistory implements SeriesResource<Order> {
     if (this.query.orderbookId) arr = arr.filter((o) => o.orderbookId === this.query.orderbookId);
     // Newest first by when the order became real. Inclusion time is the key both
     // sources report — REST sends it alongside the signed deadline, and a frame's
-    // batch *is* it — so a REST row and a streamed row sort against each other.
-    // A signed order not yet in a batch has neither and sorts to the top, which is
-    // where the newest thing belongs.
-    const at = (o: Order) => o.includedMs ?? o.deadlineMs ?? Number.MAX_SAFE_INTEGER;
+    // batch *is* it — so a REST row and a streamed row sort against each other. An
+    // order with none has not been in a batch yet, so it is newer than every order
+    // that has; the signed deadline is deliberately not a fallback, since it is a
+    // future time and would sort on a different clock.
+    const at = (o: Order) => o.includedMs ?? Number.MAX_SAFE_INTEGER;
     arr.sort((a, b) => at(b) - at(a) || b.nonce - a.nonce);
     this.handle.set(arr);
   }

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -75,7 +75,18 @@ export class OrderHistory implements SeriesResource<Order> {
    * `sinceBook` names a book *within* `since`, so the two are one fact and a
    * mismatched pair asks the server to skip books we never saw.
    */
-  private cursor: SubParams = { since: 0 };
+  private cursor: SubParams = { since: 0, sinceBook: undefined };
+
+  /**
+   * Push the cursor to the transport, both halves.
+   *
+   * `update` merges, so sending `{ since }` alone would leave whatever `sinceBook` was
+   * there before — a book from an older batch beside a newer `since`, which asks the
+   * server to skip less than it should and re-send the difference.
+   */
+  private pushCursor(): void {
+    this.sub?.update({ since: this.cursor.since, sinceBook: this.cursor.sinceBook });
+  }
 
   constructor(
     private readonly ctx: SyncContext,
@@ -149,16 +160,26 @@ export class OrderHistory implements SeriesResource<Order> {
   // --- internals ---
 
   private async fetchFirstPage(): Promise<boolean> {
+    const before = this.cursor;
     try {
       const page = await this.ctx.rest.orders(this.account, { limit: this.query.limit ?? 100 });
       if (!this.alive) return false;
-      for (const o of page.orders) this.byId.set(o.id, o);
+      // The transport resubscribes synchronously right after the `open` event that
+      // starts this fetch, so replayed frames can land while it is still in flight —
+      // and the indexer trails the stream by design. Overwriting a row the stream has
+      // already advanced would revert it, permanently: the cursor below refuses to
+      // rewind and `onFrame` drops a re-delivery, so nothing would repair it.
+      const streamMovedOn = compareCursor(this.cursor, before) > 0;
+      for (const o of page.orders) {
+        if (streamMovedOn && this.byId.has(o.id)) continue;
+        this.byId.set(o.id, o);
+      }
       this.nextCursor = page.nextCursor;
       this._hasMore = page.nextCursor !== null;
       // Only ever forward, and a page settles whole batches, so its watermark
       // carries no book — which makes it *ahead* of a stream position in the same
       // batch, not equal to it.
-      const settled: SubParams = { since: page.solutionNow * 1000 };
+      const settled: SubParams = { since: page.solutionNow * 1000, sinceBook: undefined };
       if (compareCursor(settled, this.cursor) > 0) this.cursor = settled;
       this.rebuild();
       return true;
@@ -179,7 +200,7 @@ export class OrderHistory implements SeriesResource<Order> {
           (e) => this.onSubError(e),
         );
       } else {
-        this.sub.update(this.cursor); // refresh for the next reconnect
+        this.pushCursor(); // refresh for the next reconnect
       }
     });
   }
@@ -215,7 +236,7 @@ export class OrderHistory implements SeriesResource<Order> {
       // The transport rewrote `sub.params` from the close before this ran, so without
       // pushing our own decision back the wire resumes from the server's point
       // regardless and the guard above protects nothing.
-      this.sub?.update(this.cursor);
+      this.pushCursor();
       this.sub?.resubscribe();
       return;
     }
@@ -228,14 +249,29 @@ export class OrderHistory implements SeriesResource<Order> {
     // forward. Dropping the cursor below is the backstop for when even that fresh
     // watermark is refused (the indexer further behind than the buffer retains):
     // live-only resubscribe, trading the unreplayable window for a working stream.
+    this.scheduleReseed();
+  }
+
+  /**
+   * Back off, re-seed over REST, then resubscribe — and keep trying.
+   *
+   * The re-seed can fail too (the same node is usually behind both the stream and the
+   * indexer), and a failure has to re-arm here: not resubscribing means no further
+   * close or rejection arrives, so nothing else would ever schedule another attempt and
+   * the stream would stay down with no error surfaced. Capped, so a node that keeps
+   * refusing cannot spin this.
+   */
+  private scheduleReseed(): void {
     this.subRetries++;
     const delay = Math.min(30_000, 500 * 2 ** (this.subRetries - 1));
     if (this.retryTimer) clearTimeout(this.retryTimer);
     this.retryTimer = setTimeout(() => {
       void this.fetchFirstPage().then((ok) => {
-        if (!ok || !this.alive) return;
+        if (!this.alive) return;
+        if (!ok) { this.scheduleReseed(); return; }
         const tooOld = this.subRetries > RETRIES_BEFORE_DROPPING_CURSOR;
-        this.sub?.update(tooOld ? { since: undefined, sinceBook: undefined } : this.cursor);
+        if (tooOld) this.sub?.update({ since: undefined, sinceBook: undefined });
+        else this.pushCursor();
         this.sub?.resubscribe();
       });
     }, delay);

--- a/ts-sdk/src/sync/orders.ts
+++ b/ts-sdk/src/sync/orders.ts
@@ -48,10 +48,12 @@ const WHOLE_BATCH = `0x${"ff".repeat(32)}` as MarketId;
  * comparing their bytes.
  */
 export function compareCursor(a: SubParams, b: SubParams): number {
-  const [ab, bb] = [a.since ?? 0, b.since ?? 0];
-  if (ab !== bb) return ab < bb ? -1 : 1;
-  const [abook, bbook] = [a.sinceBook ?? WHOLE_BATCH, b.sinceBook ?? WHOLE_BATCH];
-  return abook === bbook ? 0 : abook < bbook ? -1 : 1;
+  const aBatch = a.since ?? 0;
+  const bBatch = b.since ?? 0;
+  if (aBatch !== bBatch) return aBatch < bBatch ? -1 : 1;
+  const aBook = a.sinceBook ?? WHOLE_BATCH;
+  const bBook = b.sinceBook ?? WHOLE_BATCH;
+  return aBook === bBook ? 0 : aBook < bBook ? -1 : 1;
 }
 
 export class OrderHistory implements SeriesResource<Order> {
@@ -187,9 +189,12 @@ export class OrderHistory implements SeriesResource<Order> {
       // Adopt the server's watermark only when it is ahead of ours: it knows which
       // frames it handed over, but a re-seed may already have carried us past it,
       // and rewinding would re-deliver frames we have applied.
-      const closed = err as PodSubscriptionClosedError;
-      const reported: SubParams = { since: closed.resumeSince, sinceBook: closed.resumeSinceBook };
-      if (closed.resumeSince !== undefined && compareCursor(reported, this.cursor) > 0) this.cursor = reported;
+      const reported: SubParams = { since: err.resumeSince, sinceBook: err.resumeSinceBook };
+      if (err.resumeSince !== undefined && compareCursor(reported, this.cursor) > 0) this.cursor = reported;
+      // The transport rewrote `sub.params` from the close before this ran, so without
+      // pushing our own decision back the wire resumes from the server's point
+      // regardless and the guard above protects nothing.
+      this.sub?.update(this.cursor);
       this.sub?.resubscribe();
       return;
     }

--- a/ts-sdk/src/transport/ws.test.ts
+++ b/ts-sdk/src/transport/ws.test.ts
@@ -62,7 +62,7 @@ async function subscribed(withOnError = true) {
   const onMessage = vi.fn();
   const onError = vi.fn();
   const sub = client.subscribe(
-    "pod_orders",
+    "pod_orders_v2",
     { account: "0xabc", since: 500 },
     onMessage,
     withOnError ? onError : undefined,

--- a/ts-sdk/src/transport/ws.test.ts
+++ b/ts-sdk/src/transport/ws.test.ts
@@ -184,6 +184,43 @@ describe("PodWsClient subscription close", () => {
     expect(err.resumeSince).toBeUndefined();
   });
 
+  it("resumes a partly delivered batch from the (batch, book) cursor", async () => {
+    const { sub, socket, subscribeReq, notify, onError } = await subscribed();
+    accept(socket, subscribeReq);
+
+    // A `pod_orders_v2` close mid-batch: the client holds some of that batch's
+    // books, which `resume_since` alone cannot express.
+    notify({ error: {
+      code: -32020,
+      message: "subscription lagged behind the tick broadcast",
+      data: { resumable: true, resume_since: 1_718_900_000_000_000, resume_since_book: "0x07" },
+    } });
+    sub.resubscribe();
+
+    expect((onError.mock.calls[0]![0] as PodSubscriptionClosedError).resumeSinceBook).toBe("0x07");
+    const params = (socket.sentMethod("eth_subscribe")!.params as unknown[])[1] as Json;
+    expect(params.since).toBe(1_718_900_000_000_000);
+    expect(params.since_book).toBe("0x07");
+  });
+
+  it("clears the book half when the close says the batch landed whole", async () => {
+    const { sub, socket, subscribeReq, notify } = await subscribed();
+    accept(socket, subscribeReq);
+
+    // Mid-batch close, then a later one that carries no book.
+    notify({ error: { code: -32020, message: "lagged", data: { resumable: true, resume_since: 100, resume_since_book: "0x07" } } });
+    sub.resubscribe();
+    accept(socket, socket.sentMethod("eth_subscribe")!);
+    notify({ error: { code: -32020, message: "lagged", data: { resumable: true, resume_since: 200 } } });
+    sub.resubscribe();
+
+    // Carrying 0x07 into batch 200 would ask the server to skip every book at or
+    // below it there — books this client has never seen.
+    const params = (socket.sentMethod("eth_subscribe")!.params as unknown[])[1] as Json;
+    expect(params.since).toBe(200);
+    expect(params.since_book).toBeUndefined();
+  });
+
   it("surfaces a close with no onError on the client error event", async () => {
     const { client, socket, subscribeReq, notify } = await subscribed(false);
     accept(socket, subscribeReq);

--- a/ts-sdk/src/transport/ws.ts
+++ b/ts-sdk/src/transport/ws.ts
@@ -3,10 +3,10 @@
 // Ref-counted logical subscriptions, exponential backoff, idle-timeout
 // reconnect, and automatic re-subscribe (with each sub's current `since`).
 
-import type { Address, MarketId } from "../types/public.js";
+import type { Address, Hash, MarketId } from "../types/public.js";
 
 export type Channel =
-  | "pod_orderbook" | "pod_orders" | "pod_candles"
+  | "pod_orderbook" | "pod_orders" | "pod_orders_v2" | "pod_candles"
   | "pod_markets" | "pod_positions" | "pod_triggers";
 
 export interface SubParams {
@@ -14,6 +14,17 @@ export interface SubParams {
   account?: Address;
   depth?: number;
   since?: number; // micros (solution time)
+  /**
+   * `pod_orders_v2` only: the `book` of the last frame accepted at `since`,
+   * completing the resume cursor.
+   *
+   * One batch settles many orderbooks and is delivered as one frame each, so a
+   * client can hold part of a batch, and `since` alone cannot express that
+   * position. With this set, replay skips every book at or below it within
+   * `since`, then delivers later batches whole. Omitted means the whole of
+   * `since` arrived — what `since` means on every other channel.
+   */
+  sinceBook?: Hash;
 }
 
 export interface Subscription {
@@ -45,6 +56,7 @@ interface WireCloseError {
   data?: {
     resumable?: unknown;
     resume_since?: unknown;
+    resume_since_book?: unknown;
     missed?: unknown;
   };
 }
@@ -61,7 +73,7 @@ const asString = (v: unknown) => (typeof v === "string" ? v : undefined);
  * subscription's `since` to `resumeSince`, so restarting it is one call:
  *
  * ```ts
- * const sub = ws.subscribe("pod_orders", { account }, onUpdate, (err) => {
+ * const sub = ws.subscribe("pod_orders_v2", { account }, onFrame, (err) => {
  *   if (err instanceof PodSubscriptionClosedError && err.resumable) sub.resubscribe();
  * });
  * ```
@@ -80,6 +92,11 @@ export class PodSubscriptionClosedError extends Error {
    * had not yet taken a whole tick.
    */
   readonly resumeSince?: number;
+  /**
+   * `pod_orders_v2` only: the last book of `resumeSince` that was delivered, when
+   * that batch was only partly delivered. Absent means the batch landed whole.
+   */
+  readonly resumeSinceBook?: Hash;
   /** `-32020` only: how many ticks the broadcast dropped. */
   readonly missed?: number;
   /** The raw `params.error`, for fields this version does not map. */
@@ -94,6 +111,7 @@ export class PodSubscriptionClosedError extends Error {
     // close we failed to understand can hot-loop, which is the worse failure.
     this.resumable = data.resumable === true;
     this.resumeSince = asNumber(data.resume_since);
+    this.resumeSinceBook = asString(data.resume_since_book) as Hash | undefined;
     this.missed = asNumber(data.missed);
     this.raw = raw;
   }
@@ -265,6 +283,7 @@ export class PodWsClient {
     if (p.account) out.account = p.account; // server aliases to `bidder`
     if (p.depth !== undefined) out.depth = p.depth;
     if (p.since !== undefined) out.since = p.since;
+    if (p.sinceBook !== undefined) out.since_book = p.sinceBook;
     return out;
   }
 
@@ -318,7 +337,11 @@ export class PodWsClient {
           // is the gap the close frame exists to prevent. Doing it here also
           // means `resubscribe()` alone resumes correctly.
           if (closed.resumable && closed.resumeSince !== undefined) {
-            sub.params = { ...sub.params, since: closed.resumeSince };
+            // Both halves, together. A close with no `resume_since_book` says the
+            // batch landed whole, so the stored book must be cleared rather than
+            // carried over: it belongs to an older batch, and leaving it would
+            // ask the server to skip books inside the new one.
+            sub.params = { ...sub.params, since: closed.resumeSince, sinceBook: closed.resumeSinceBook };
           }
           if (sub.onError) sub.onError(closed);
           else this.emit("error", closed);

--- a/ts-sdk/src/transport/ws.ts
+++ b/ts-sdk/src/transport/ws.ts
@@ -6,7 +6,7 @@
 import type { Address, MarketId } from "../types/public.js";
 
 export type Channel =
-  | "pod_orderbook" | "pod_orders" | "pod_orders_v2" | "pod_candles"
+  | "pod_orderbook" | "pod_orders_v2" | "pod_candles"
   | "pod_markets" | "pod_positions" | "pod_triggers";
 
 export interface SubParams {

--- a/ts-sdk/src/transport/ws.ts
+++ b/ts-sdk/src/transport/ws.ts
@@ -3,7 +3,7 @@
 // Ref-counted logical subscriptions, exponential backoff, idle-timeout
 // reconnect, and automatic re-subscribe (with each sub's current `since`).
 
-import type { Address, Hash, MarketId } from "../types/public.js";
+import type { Address, MarketId } from "../types/public.js";
 
 export type Channel =
   | "pod_orderbook" | "pod_orders" | "pod_orders_v2" | "pod_candles"
@@ -24,7 +24,7 @@ export interface SubParams {
    * `since`, then delivers later batches whole. Omitted means the whole of
    * `since` arrived — what `since` means on every other channel.
    */
-  sinceBook?: Hash;
+  sinceBook?: MarketId;
 }
 
 export interface Subscription {
@@ -96,7 +96,7 @@ export class PodSubscriptionClosedError extends Error {
    * `pod_orders_v2` only: the last book of `resumeSince` that was delivered, when
    * that batch was only partly delivered. Absent means the batch landed whole.
    */
-  readonly resumeSinceBook?: Hash;
+  readonly resumeSinceBook?: MarketId;
   /** `-32020` only: how many ticks the broadcast dropped. */
   readonly missed?: number;
   /** The raw `params.error`, for fields this version does not map. */
@@ -111,7 +111,7 @@ export class PodSubscriptionClosedError extends Error {
     // close we failed to understand can hot-loop, which is the worse failure.
     this.resumable = data.resumable === true;
     this.resumeSince = asNumber(data.resume_since);
-    this.resumeSinceBook = asString(data.resume_since_book) as Hash | undefined;
+    this.resumeSinceBook = asString(data.resume_since_book) as MarketId | undefined;
     this.missed = asNumber(data.missed);
     this.raw = raw;
   }

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -118,6 +118,11 @@ export interface Order {
   id: Hash;
   txHash: Hash;
   orderbookId?: MarketId;
+  /**
+   * Whether the book is spot or perp, when the source said so — REST rows carry it,
+   * streamed ones do not. It is static market metadata rather than a fact about the
+   * order, so the reliable read is a join: `markets.find((m) => m.id === o.orderbookId)?.type`.
+   */
   marketType?: MarketType;
   side: OrderSide;
   orderType: OrderType;

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -32,6 +32,54 @@ export type OrderDirection =
   | "open_short" | "add_short" | "reduce_short" | "close_short"
   | "long_to_short" | "short_to_long" | "liquidation";
 
+/**
+ * Why the engine refused something, as a stable identifier to branch on.
+ *
+ * Open by design: a newer node may report a code this version does not list, so
+ * treat an unrecognised one like `"unspecified"` — the accompanying `message` is
+ * then all there is. `"unspecified"` itself means the engine has not given that
+ * reason a name yet.
+ */
+export type RejectCode =
+  | "insufficient_balance" | "invalid_price" | "zero_size" | "notional_below_minimum"
+  | "unknown_market" | "order_not_found" | "not_order_owner" | "stale_nonce"
+  | "wrong_pair" | "engine_managed_order" | "price_above_maximum" | "price_off_tick"
+  | "market_order_must_be_ioc" | "size_above_maximum" | "size_off_lot"
+  | "notional_overflow" | "notional_above_cap" | "unspecified"
+  | (string & {});
+
+/**
+ * An amendment the engine refused. The order itself is untouched — this is the
+ * answer to a price/size change that did not happen.
+ *
+ * The requested price and size are echoed back because a client may have several
+ * amendments outstanding on one order, and they are how it tells which one this
+ * answers. Only the latest refusal is kept.
+ */
+export interface AmendRejection {
+  /** The price that was asked for. */
+  requestedPrice: bigint;
+  /** The size that was asked for, as an unsigned magnitude. */
+  requestedSize: bigint;
+  /** Branch on this rather than on `message`. */
+  code: RejectCode;
+  /**
+   * Present only when the reason carries detail the code cannot — the amounts on
+   * `insufficient_balance`, `invalid_price` and `notional_below_minimum`, the pair on
+   * `unknown_market`, and the whole reason on `unspecified`. For every other code the
+   * message would just restate the code.
+   */
+  message?: string;
+  /**
+   * Who asked. Deliberately not the order's owner: a refusal says nothing about who
+   * owns the order, and on `not_order_owner` the requester is precisely who does not.
+   * Absent when the stream names a single account.
+   */
+  requestedBy?: Address;
+  /** The batch the refusal landed in (ms). */
+  batchMs: number;
+}
+
 export interface TokenInfo {
   address: Address;
   symbol: string;
@@ -150,6 +198,12 @@ export interface Order {
   fills: PartialFill[];
   /** Why the engine rejected the order; set only on `status: "invalid"`. */
   rejectReason?: string;
+  /**
+   * The latest amendment the engine refused for this order, if any. The order is
+   * unchanged by it — without this, a refused price change is indistinguishable from
+   * one still in flight.
+   */
+  amendRejected?: AmendRejection;
   // perpetual-only
   reduceOnly?: boolean;
   ioc?: boolean;

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -267,7 +267,8 @@ export interface Trigger {
   reduceOnly: boolean;
   ioc: boolean;
   deadlineMs: number;
-  endMs: number;
+  /** TTL expiry (ms). Undefined when the trigger never expires. */
+  endMs?: number;
 }
 
 export interface BackstopTransfer {

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -54,7 +54,7 @@ export type RejectCode =
  *
  * The requested price and size are echoed back because a client may have several
  * amendments outstanding on one order, and they are how it tells which one this
- * answers. Only the latest refusal is kept.
+ * answers.
  */
 export interface AmendRejection {
   /** The price that was asked for. */
@@ -120,9 +120,10 @@ export interface OrderEventFill extends PartialFill {
  * partial, and a transition that changes nothing about the order — a refused amendment
  * — is invisible without a synthetic marker to spot it by.
  *
- * Deliberately lean. `order` is the row as the whole frame left it, and the detail that
- * belongs to the order rather than to the event (a reject's `rejectReason`, a refusal's
- * `amendRejected`) is read from there.
+ * Deliberately lean. `order` is the row as the whole frame left it, so durable state a
+ * transition leaves behind is read from there — a `reject`'s `rejectReason` annotates the
+ * `invalid` status it set. Detail that belongs to the transition itself, and describes
+ * nothing about the order afterwards, is on the event: `fill`, and `amendRejection`.
  */
 export interface OrderEvent {
   kind: OrderEventKind;
@@ -138,6 +139,16 @@ export interface OrderEvent {
   batchMs: number;
   /** `fill` only: this fill alone, not a running total. */
   fill?: OrderEventFill;
+  /**
+   * `modify_reject` only: the amendment the engine refused.
+   *
+   * On the event rather than on `order`, because the order is exactly what it is not
+   * about — a refusal changes nothing about it. Parked on the entity it would be
+   * write-once and never cleared, so an order would keep reporting a refusal it had
+   * long since amended past, and only when the row came from this stream rather than
+   * from REST.
+   */
+  amendRejection?: AmendRejection;
 }
 
 export interface TokenInfo {
@@ -258,12 +269,6 @@ export interface Order {
   fills: PartialFill[];
   /** Why the engine rejected the order; set only on `status: "invalid"`. */
   rejectReason?: string;
-  /**
-   * The latest amendment the engine refused for this order, if any. The order is
-   * unchanged by it — without this, a refused price change is indistinguishable from
-   * one still in flight.
-   */
-  amendRejected?: AmendRejection;
   // perpetual-only
   reduceOnly?: boolean;
   ioc?: boolean;

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -94,6 +94,14 @@ export type TerminalStatus = Extract<OrderStatus, "filled" | "canceled" | "margi
 /** One fill, plus the status it closed the order with when it did. */
 export interface OrderEventFill extends PartialFill {
   /**
+   * Base filled over the order's life **as of this fill**.
+   *
+   * Not the same as `order.filledBase`, which is where the *whole frame* left the order:
+   * two fills of one order in one batch would otherwise both report the final total,
+   * so neither matches the fill it is attached to.
+   */
+  totalBase: bigint;
+  /**
    * Absent while the order is still working.
    *
    * `margin_canceled` here is the engine evicting the order for margin, reported on the

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -117,10 +117,8 @@ export interface PartialFill {
 export interface Order {
   id: Hash;
   txHash: Hash;
-  orderbookId?: MarketId; // REST orders; WS stream orders carry `pair` instead
+  orderbookId?: MarketId;
   marketType?: MarketType;
-  /** Token-address pair (base/quote); present on WS stream orders. */
-  pair?: { base: Address; quote: Address };
   side: OrderSide;
   orderType: OrderType;
   status: OrderStatus;
@@ -134,10 +132,13 @@ export interface Order {
   fee: bigint;
   effectivePrice?: bigint;
   deadlineMs: number;
-  endMs: number;
-  /** Batch-inclusion time (ms) — when the order entered the book. REST history only. */
+  /** TTL expiry (ms). Undefined when the order never expires. */
+  endMs?: number;
+  /** Batch-inclusion time (ms) — when the order entered the book. */
   includedMs?: number;
   fills: PartialFill[];
+  /** Why the engine rejected the order; set only on `status: "invalid"`. */
+  rejectReason?: string;
   // perpetual-only
   reduceOnly?: boolean;
   ioc?: boolean;

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -136,7 +136,13 @@ export interface Order {
   filledQuote: bigint;
   fee: bigint;
   effectivePrice?: bigint;
-  deadlineMs: number;
+  /**
+   * The auction deadline the order was signed for (ms). REST only: it is a fact
+   * about the intent, not about when the order became real, and the
+   * `pod_orders_v2` frame does not carry it. To order orders, use `includedMs` —
+   * both sources report that.
+   */
+  deadlineMs?: number;
   /** TTL expiry (ms). Undefined when the order never expires. */
   endMs?: number;
   /** Batch-inclusion time (ms) — when the order entered the book. */

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -85,6 +85,26 @@ export type OrderEventKind =
   | "new" | "reject" | "fill" | "cancel" | "expire" | "modify" | "modify_reject";
 
 /**
+ * The statuses an order can *close* with. Narrower than `OrderStatus`, which also
+ * covers the states a live order passes through — so a `switch` over this one can be
+ * exhaustive.
+ */
+export type TerminalStatus = Extract<OrderStatus, "filled" | "canceled" | "margin_canceled" | "expired">;
+
+/** One fill, plus the status it closed the order with when it did. */
+export interface OrderEventFill extends PartialFill {
+  /**
+   * Absent while the order is still working.
+   *
+   * `margin_canceled` here is the engine evicting the order for margin, reported on the
+   * fill that closed it. An eviction that closes an order *without* a fill arrives as a
+   * plain `cancel` instead: the wire cannot yet distinguish it from a user cancel (ADR
+   * 0029 §6 reserves a `why` for that), so do not try to re-derive it from `status`.
+   */
+  closedAs?: TerminalStatus;
+}
+
+/**
  * One transition the stream reported.
  *
  * The alternative is diffing consecutive snapshots, which can only see net state: two
@@ -98,15 +118,18 @@ export type OrderEventKind =
  */
 export interface OrderEvent {
   kind: OrderEventKind;
-  /** The order it happened to, as the whole frame left it. */
+  /**
+   * The order it happened to, as the whole frame left it.
+   *
+   * A live row, not a copy: the stream mutates it in place as later frames arrive. Read
+   * it in the callback, and copy it if you keep it — a buffered event would otherwise
+   * show the order's present state rather than its state at the time.
+   */
   order: Order;
   /** The batch it landed in (ms). */
   batchMs: number;
-  /**
-   * `fill` only: this fill alone — not a running total — plus the status it closed the
-   * order with, when it did.
-   */
-  fill?: PartialFill & { closedAs?: OrderStatus };
+  /** `fill` only: this fill alone, not a running total. */
+  fill?: OrderEventFill;
 }
 
 export interface TokenInfo {

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -80,6 +80,35 @@ export interface AmendRejection {
   batchMs: number;
 }
 
+/** What the engine did to an order, as `pod_orders_v2` reports it (ADR 0029 §3). */
+export type OrderEventKind =
+  | "new" | "reject" | "fill" | "cancel" | "expire" | "modify" | "modify_reject";
+
+/**
+ * One transition the stream reported.
+ *
+ * The alternative is diffing consecutive snapshots, which can only see net state: two
+ * fills in one batch collapse into one change, a fill that closes an order hides the
+ * partial, and a transition that changes nothing about the order — a refused amendment
+ * — is invisible without a synthetic marker to spot it by.
+ *
+ * Deliberately lean. `order` is the row as the whole frame left it, and the detail that
+ * belongs to the order rather than to the event (a reject's `rejectReason`, a refusal's
+ * `amendRejected`) is read from there.
+ */
+export interface OrderEvent {
+  kind: OrderEventKind;
+  /** The order it happened to, as the whole frame left it. */
+  order: Order;
+  /** The batch it landed in (ms). */
+  batchMs: number;
+  /**
+   * `fill` only: this fill alone — not a running total — plus the status it closed the
+   * order with, when it did.
+   */
+  fill?: PartialFill & { closedAs?: OrderStatus };
+}
+
 export interface TokenInfo {
   address: Address;
   symbol: string;

--- a/ts-sdk/src/types/wire.ts
+++ b/ts-sdk/src/types/wire.ts
@@ -325,8 +325,20 @@ export interface WireOrderEvent {
   o?: number;
   id?: Hex;
   a?: number;
-  /** `reject`: why the engine dropped the order. */
+  /** `reject`: why the engine dropped the order. `modify_reject`: detail the `code` cannot carry. */
   why?: string;
+  /**
+   * `modify_reject`: index into `accts` for the account that *asked*, which is not
+   * necessarily the order's owner — hence not `a`. On `not_order_owner` the requester
+   * is precisely who does not own it.
+   */
+  by?: number;
+  /** `modify_reject`: the price that was asked for. */
+  req_px?: WireDecimal;
+  /** `modify_reject`: the size that was asked for, unsigned. */
+  req_sz?: WireDecimal;
+  /** `modify_reject`: the stable reason identifier — branch on this, not on `why`. */
+  code?: string;
   /** `fill`: base filled by **this** fill. */
   b?: WireDecimal;
   /** `fill`: quote filled by this fill. */

--- a/ts-sdk/src/types/wire.ts
+++ b/ts-sdk/src/types/wire.ts
@@ -3,7 +3,7 @@
 // strings; timestamps are microseconds (in `*_us` fields, or bare on candle/
 // orderbook). Decoders in ../codec/decode.ts convert these to ../types/public.
 
-import type { Hex } from "./public.js";
+import type { Hex, OrderEventKind } from "./public.js";
 
 export type WireDecimal = string; // 1e18-scaled integer as a decimal string
 
@@ -321,7 +321,7 @@ export interface WireOrderEntity {
  * would make an unrecognised kind unrepresentable.
  */
 export interface WireOrderEvent {
-  k: "new" | "reject" | "fill" | "cancel" | "expire" | "modify" | "modify_reject" | (string & {});
+  k: OrderEventKind | (string & {});
   o?: number;
   id?: Hex;
   a?: number;

--- a/ts-sdk/src/types/wire.ts
+++ b/ts-sdk/src/types/wire.ts
@@ -89,8 +89,9 @@ export interface WirePartialFill {
 }
 
 export interface WireOrder {
-  orderbook_id?: Hex; // REST only; WS raw Order carries `pair` instead
-  market_type?: "spot" | "perp"; // REST only
+  orderbook_id?: Hex;
+  /** The order endpoints say "perpetual" where `/clob/markets` says "perp". */
+  market_type?: "spot" | "perp" | "perpetual";
   kind: string;
   order_id: Hex;
   tx_hash: Hex;
@@ -108,9 +109,6 @@ export interface WireOrder {
   included_batch?: number | string; // micros; batch-inclusion time (REST order history)
   effective_price?: WireDecimal | null;
   fills?: WirePartialFill[];
-  /** Present on WS stream orders (raw engine Order) instead of orderbook_id. */
-  pair?: { base: Hex; quote: Hex };
-  /** Present on REST orders; absent on the WS raw Order (derive from `initial_size`). */
   side?: "buy" | "sell";
   reduce_only?: boolean;
   ioc?: boolean;
@@ -263,29 +261,95 @@ export interface WireBackstopPage {
   solution_now: number;
 }
 
-// pod_orders push: tagged union on `type`.
-export type WireOrderUpdate =
-  | ({ type: "new" } & WireOrder)
-  | ({ type: "invalid" } & WireOrder)
-  | ({ type: "fill" } & WireOrderFill)
-  | { type: "expired"; order_id: Hex }
-  | { type: "canceled"; order_id: Hex }
-  | { type: "modified"; order_id: Hex; new_price: WireDecimal; new_size: WireDecimal };
+// --- pod_orders_v2 push (ADR 0029) ---
+//
+// One notification is one frame: everything that happened to one orderbook in one
+// auction batch. The book and the batch are named once, orders created in the
+// batch appear once in `orders`, and `events` are transitions referencing them.
+// Optional fields are omitted at their default rather than sent, so each absence
+// means something specific — noted per field.
 
-export interface WireOrderFill {
-  orderbook_id: Hex;
-  order_id: Hex;
-  tx_hash: Hex;
-  bidder: Hex;
-  status: string;
-  base_amount: WireDecimal;
-  quote_amount: WireDecimal;
-  filled_base_amount: WireDecimal;
-  filled_quote_amount: WireDecimal;
-  effective_price?: WireDecimal | null;
-  fee: WireDecimal;
-  position_before?: WireDecimal | null;
-  position_after?: WireDecimal | null;
+export interface WireOrdersFrame {
+  /** The orderbook these actions happened on; constant for the frame. */
+  book: Hex;
+  /** Deadline (micros) of the batch the actions **landed in**. Half of the resume cursor; `book` is the other half. */
+  batch: number;
+  /**
+   * Owner addresses, indexed by `orders[].a` and by events that name an order by
+   * `id`. Omitted when the subscription names exactly one account — decode on
+   * this field, not on the filter that was sent.
+   */
+  accts?: Hex[];
+  orders: WireOrderEntity[];
+  events: WireOrderEvent[];
+}
+
+/** An order as admitted: the facts that do not change. Its status is implied by the events. */
+export interface WireOrderEntity {
+  id: Hex;
+  /** Creating transaction, or its parent `submitBatch` envelope. */
+  tx: Hex;
+  /** Index into the frame's `accts`; present iff `accts` is. */
+  a?: number;
+  n: number;
+  px: WireDecimal;
+  /** Signed size: the sign carries the side, so there is no side field. */
+  sz: WireDecimal;
+  /** TTL expiry (micros). **Omitted means the order never expires.** */
+  end?: number;
+  /** **Omitted means user-signed.** */
+  kind?: string;
+  /** **Omitted means a limit order.** */
+  type?: "market";
+  /** Omitted means false. */
+  reduce_only?: boolean;
+  /** Omitted means false. */
+  ioc?: boolean;
+  /** Omitted unless the order is a fired trigger's synthetic. */
+  trigger?: string;
+  /** Omitted when ungrouped. */
+  grouping?: string;
+}
+
+/**
+ * One transition, discriminated by `k`. Every event names its order by exactly
+ * one of `o` (an index into this frame's `orders`) or `id` (resting from an
+ * earlier batch, owned by `accts[a]`).
+ *
+ * Kinds are open: unknown values of `k` must be ignored rather than rejected, so
+ * this is a plain shape with per-kind optional fields rather than a union that
+ * would make an unrecognised kind unrepresentable.
+ */
+export interface WireOrderEvent {
+  k: "new" | "reject" | "fill" | "cancel" | "expire" | "modify" | (string & {});
+  o?: number;
+  id?: Hex;
+  a?: number;
+  /** `reject`: why the engine dropped the order. */
+  why?: string;
+  /** `fill`: base filled by **this** fill. */
+  b?: WireDecimal;
+  /** `fill`: quote filled by this fill. */
+  q?: WireDecimal;
+  /**
+   * Total base filled over the order's life so far.
+   *
+   * Carried by `fill`, `cancel` and `expire` alike (ADR 0029 §4.1): a terminated
+   * order reports what it had filled, as an explicit zero rather than an omission,
+   * so absence never has to be read as zero. Optional only because this one shape
+   * covers every kind — `new`, `reject` and `modify` have no totals to report.
+   */
+  tb?: WireDecimal;
+  /** Total quote filled so far; travels with `tb`. */
+  tq?: WireDecimal;
+  /** Total fee charged so far; travels with `tb`. There is no per-fill counterpart. */
+  tf?: WireDecimal;
+  /** `fill`: present only on the fill that closed the order, carrying its terminal status. */
+  st?: "filled" | "canceled" | "margin_canceled" | "expired";
+  /** `modify`: the price after the change. */
+  px?: WireDecimal;
+  /** `modify`: the size after the change, as an **unsigned magnitude**. */
+  sz?: WireDecimal;
 }
 
 export interface WirePositionsPush {

--- a/ts-sdk/src/types/wire.ts
+++ b/ts-sdk/src/types/wire.ts
@@ -321,7 +321,7 @@ export interface WireOrderEntity {
  * would make an unrecognised kind unrepresentable.
  */
 export interface WireOrderEvent {
-  k: "new" | "reject" | "fill" | "cancel" | "expire" | "modify" | (string & {});
+  k: "new" | "reject" | "fill" | "cancel" | "expire" | "modify" | "modify_reject" | (string & {});
   o?: number;
   id?: Hex;
   a?: number;

--- a/ts-sdk/src/types/wire.ts
+++ b/ts-sdk/src/types/wire.ts
@@ -346,6 +346,16 @@ export interface WireOrderEvent {
   tf?: WireDecimal;
   /** `fill`: present only on the fill that closed the order, carrying its terminal status. */
   st?: "filled" | "canceled" | "margin_canceled" | "expired";
+  /**
+   * `fill` on a perp market: the owner's position after this fill, signed and
+   * 1e18-scaled. Omitted on spot, which has no position.
+   *
+   * The position *before* is not sent because it is derivable — `pa - sign(sz) * b`,
+   * the same arithmetic the engine used to produce the pair — and the transition
+   * between the two is what says whether the fill opened, added to, reduced, closed
+   * or flipped the position.
+   */
+  pa?: WireDecimal;
   /** `modify`: the price after the change. */
   px?: WireDecimal;
   /** `modify`: the size after the change, as an **unsigned magnitude**. */

--- a/ts-sdk/src/write/index.ts
+++ b/ts-sdk/src/write/index.ts
@@ -689,7 +689,7 @@ export function buildWaitlistDeposit(p: WaitlistDepositParams): SourceChainCall 
  * matching the engine (`trading/src/lib.rs`). `sequence` is the 0-based index
  * of the intent within a `submitBatch` (0 for a single-intent tx). Needs the
  * nonce, so it's only known up-front in managed mode; in advisory mode reconcile
- * by `tx_hash` from the `pod_orders` stream instead.
+ * by `tx` from the `pod_orders_v2` stream instead.
  */
 export function deriveOrderId(signer: Address, nonce: number, sequence = 0): Hash {
   return keccak256(


### PR DESCRIPTION
Migrates `@pod-network/trade-sdk`'s order stream from `pod_orders` to `pod_orders_v2` (ADR 0029), and turns it from a snapshot store into one that also reports what changed.

The v1 decode path is gone rather than kept beside the new one. Two paths producing the same `Order` means two places to fix every future field, and the interesting parts of v2 — the resume cursor, the event kinds — have no v1 equivalent to fall back to.

## Why, given that v2 is not smaller

Measured on staging over one 90s window with both channels subscribed at once and the same `bidder` filter: v1 584 bytes/frame, v2 634. Staging is close to 100% market-maker `modify` traffic at ~3.5 events per frame, and v2's per-frame envelope (a 66-char `book`, plus `batch`) costs more than its shorter keys save at that width. ADR 0029's 61% figure assumes a 33-event tick, which a busier book will reach.

The reasons to move are the identity and resume properties. Every frame names its book and its auction batch, so `batch` dates an order by the tick that admitted it — which is what "newest" means here, and what v1 could not express. That fixed a real ordering bug in the app: REST rows carry a future `deadline`, streamed rows a past batch, and sorting the two together put not-yet-expired orders above ones that had just filled.

## The resume cursor is a pair, and it has to match the server's

A batch is delivered as one frame per book, so the position is `(batch, book)` — and an absent book means the whole batch, sorting **above** every book in it. This mirrors `already_delivered` in `node/src/rpc/orders_v2.rs`. If the two sides disagree the server re-sends frames the client already applied, and applying a fill frame twice appends the fill twice, so the order reads as having filled more than it did.

`compareCursor` is exported and directly tested for that reason, including the case that motivated it: a REST page settles whole batches, so its watermark has no book, and reading that as "book zero" moved the cursor backwards from "all of batch 5" to "up to book 1 of batch 5".

## Transitions, not just state

`onEvent` reports the decoded events of each frame. Consumers previously had to diff consecutive snapshots to find out what happened, which cannot distinguish "this order filled" from "this order was already filled when I first saw it" — so a reconnect re-announced every fill in the replay window. The events are the stream's own account of what changed, and the app's notification logic went from a diff engine to one line.

`onEvent` also counts as a subscriber. The resource is ref-counted from `subscribe`/`ready`, so an event-only consumer used to wait forever unless something else happened to hold the same instance.

Notable decodes: `pa` classifies a perp fill's direction through a branch-for-branch port of the node's classifier (podnetwork/pod#1655 sends the field); `modify_reject` surfaces a refused amendment with its stable `code`; `st` gives a fill the terminal status it closed the order as, so a partial fill that then expired is not reported as filled.

## Known gap

A `modify_reject` for an order outside the replay window (`order_not_found`) produces no event — there is no order to attach it to. Fixing it properly needs an API-shape decision (an orderless event, or a separate channel), so it is left out rather than guessed at.

## Requires a node upgrade before the app ships

`pa`, `modify_reject` and terminal totals on `cancel`/`expire` are all dormant against staging's current node. The decode paths handle their absence, but a consumer that relies on them — the frontend does — must not ship before the node does.

## Version

`0.3.0`, not `0.2.0`. `0.2.0` shipped from main while this was open (`fa7fbac`, the waitlist deposit builders from #267), so the version this branch originally claimed is published and cannot be reused. Rebased onto the release and bumped past it.

Minor rather than patch because this is breaking, which is what a minor bump says pre-1.0: `Order.amendRejected` is gone (the refusal moved to `OrderEvent.amendRejection`) and `pod_orders` is gone from `Channel`.
