### PR TITLE
ci: publish the JSON-RPC OpenAPI spec to GitBook on merge

### DIFF
--- a/.github/workflows/gitbook-openapi-publish.yml
+++ b/.github/workflows/gitbook-openapi-publish.yml
@@ -1,0 +1,78 @@
+name: Publish OpenAPI to GitBook
+
+# GitBook does not render the spec file in this repo. It renders the spec
+# registered in the organization as `pod-docs` — see the `builtin:openapi` block
+# under JSON-RPC in doc/api-reference/SUMMARY.md, whose dependency is
+# `kind: openapi, spec: pod-docs`. So merging a spec change here left the
+# published reference stale until someone re-uploaded the file by hand in the
+# GitBook UI. This publishes it on merge instead.
+on:
+  push:
+    branches: ["main"]
+    # Deliberately narrower than GitBook's sample workflow, which watches
+    # **/*.yaml, **/*.yml and **/*.json — in this repo that fires on every
+    # workflow edit, lockfile bump and protocol config, republishing an
+    # unchanged spec each time.
+    paths:
+      - "doc/api-reference/json-rpc/openapi.yaml"
+  # Republish on demand: recovers from a failed run, or from a spec edited
+  # directly in GitBook that should be reset to what main says.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Publish one at a time. Two merges in quick succession would otherwise race,
+# and whichever run finished last would decide the published spec regardless of
+# which commit is newer. Queued rather than cancelled so the final state always
+# matches the last merge.
+concurrency:
+  group: gitbook-openapi-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      # The CLI reads the token from the environment; `openapi publish` has no
+      # token flag, and a flag would put the credential in the process list.
+      GITBOOK_TOKEN: ${{ secrets.GITBOOK_TOKEN }}
+      # Not a credential (it appears in GitBook URLs), so it lives in repo
+      # variables rather than secrets — a secret would be masked in the logs of
+      # the very step whose failures are diagnosed by reading it.
+      GITBOOK_ORGANIZATION_ID: ${{ vars.GITBOOK_ORGANIZATION_ID }}
+      # Committed rather than configured: this name is already in the repo, in
+      # SUMMARY.md's openapi block, and the two must agree or the docs render a
+      # spec this workflow never updates. An unset variable would silently
+      # publish somewhere else.
+      GITBOOK_SPEC_NAME: pod-docs
+      SPEC_PATH: doc/api-reference/json-rpc/openapi.yaml
+    steps:
+      - uses: actions/checkout@v5
+
+      # Fail with a message that names the setting to fix. Without this, a
+      # missing token surfaces as a bare `[401] Invalid authentication token`
+      # and a missing organization as a not-found, both of which read like a
+      # GitBook outage rather than a repo misconfiguration.
+      - name: Check GitBook credentials are configured
+        run: |
+          if [ -z "$GITBOOK_TOKEN" ]; then
+            echo "::error::GITBOOK_TOKEN is not set (Settings -> Secrets and variables -> Actions -> Secrets)"
+            exit 1
+          fi
+          if [ -z "$GITBOOK_ORGANIZATION_ID" ]; then
+            echo "::error::GITBOOK_ORGANIZATION_ID is not set (Settings -> Secrets and variables -> Actions -> Variables)"
+            exit 1
+          fi
+
+      # Pinned, not @latest: this step holds write access to the published API
+      # reference, so a new CLI release should arrive as a reviewed bump here
+      # rather than silently on the next merge. 0.30.0 is the current stable
+      # release, and its `openapi publish` takes `--spec`/`--organization` plus
+      # the spec path.
+      - name: Publish spec to GitBook
+        run: |
+          npx -y @gitbook/cli@0.30.0 openapi publish \
+            --spec "$GITBOOK_SPEC_NAME" \
+            --organization "$GITBOOK_ORGANIZATION_ID" \
+            "$SPEC_PATH"

--- a/.github/workflows/gitbook-openapi-publish.yml
+++ b/.github/workflows/gitbook-openapi-publish.yml
@@ -65,6 +65,18 @@ jobs:
             exit 1
           fi
 
+      # Pinning the CLI is only half of a reproducible publish — the runtime it
+      # runs on has to be pinned too. @gitbook/cli declares `node >= 18` with no
+      # upper bound, and the runner image moves forward on its own schedule, so
+      # without this the step eventually executes on a Node major the CLI has
+      # never been tested against. Matches publish-ts-sdk.yml's pin. Runs after
+      # the guard so a misconfigured repo fails in seconds without provisioning
+      # a toolchain first, and without `cache` because no lockfile governs an
+      # `npx` install.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       # Pinned, not @latest: this step holds write access to the published API
       # reference, so a new CLI release should arrive as a reviewed bump here
       # rather than silently on the next merge. 0.30.0 is the current stable


### PR DESCRIPTION
## What

Adds `.github/workflows/gitbook-openapi-publish.yml`: on a push to `main` that touches `doc/api-reference/json-rpc/openapi.yaml`, publish that spec to GitBook with the GitBook CLI. `workflow_dispatch` is wired up as well, to republish after a failed run or to reset a spec that was edited directly in GitBook back to what `main` says.

## Why

GitBook does not render the spec file in this repo. It renders the spec registered in the organization as `pod-docs` — see the `builtin:openapi` block under JSON-RPC in `doc/api-reference/SUMMARY.md`, whose dependency is `kind: openapi, spec: pod-docs`. So merging a spec change here left the published reference stale until someone re-uploaded the file by hand in the GitBook UI. This closes that gap.

## Configuration

`GITBOOK_TOKEN` is a repo **secret** and is already added. `GITBOOK_ORGANIZATION_ID` is a repo **variable** and still needs to be set — it is not a credential (it appears in GitBook URLs), and making it a secret would mask it in the logs of the very step whose failures are diagnosed by reading it.

The token is passed through the environment rather than a flag: `openapi publish` has no token option, and a flag would put the credential in the process list. The CLI does read it from the environment — probed against `0.30.0` with a deliberately invalid `GITBOOK_TOKEN`, which produced `[401] Invalid authentication token` (it sent that token) rather than a "no stored credentials" error, so no separate `gitbook auth` step is needed.

The spec name `pod-docs` is committed rather than configured. It already lives in `SUMMARY.md`, the two must agree or the docs render a spec this workflow never updates, and an unset variable would silently publish somewhere else.

## Two deliberate deviations from GitBook's sample workflow

**Pinned CLI, not `@latest`.** This step holds write access to the published API reference, so a new CLI release should arrive as a reviewed bump here rather than silently on the next merge. `0.30.0` is the current stable release — the package's only dist-tag is `latest` → `0.30.0`, with no prerelease channel — and `openapi publish --help` at that version confirms it takes `--spec`, `--organization` and the spec path.

**Narrow trigger.** Their sample watches `**/*.yaml`, `**/*.yml` and `**/*.json`, which in this repo fires on every workflow edit, lockfile bump and protocol config, republishing an unchanged spec each time. This watches the one spec path.

Also added: `concurrency` with `cancel-in-progress: false`, so two merges in quick succession queue instead of racing. Without it, whichever run finished last would decide the published spec regardless of which commit is newer.

## What the first run will prove

The publish itself cannot be exercised without the real token and the organization id, so the first merge is the real test. Everything around it is checked: the workflow YAML parses, the trigger path matches the spec file that exists in the repo, and the guard step is shellcheck-clean and behaves in all three states — no token names the secret, token-but-no-organization names the variable, both present passes. If the organization variable is missing when this lands, the guard fails the run with the setting to add instead of publishing anywhere.

Follow-up, unrelated to this workflow: `deploy-doc-site.yml` triggers on `paths: docs/**`, but the docs live in `doc/`, so that Vercel deploy never fires on documentation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
