### PR TITLE
ts-sdk: withdraw a CLOB balance to the claim chain (ADR 0033)

### DIFF
--- a/ts-sdk/README.md
+++ b/ts-sdk/README.md
@@ -57,7 +57,11 @@ const ob = useSyncExternalStore(
   object for the TradingView Charting Library (framework-agnostic, no React).
 
 All monetary values are `bigint` (1e18-scaled; use `formatAmount`/`toNumber`/
-`parseAmount`); all timestamps are millisecond `number`s.
+`parseAmount`); all timestamps are millisecond `number`s — with one deliberate
+exception, `Withdrawal.timeUs`, which stays in **microseconds** because it is
+also the resume cursor for `pod_withdrawals` and its REST backfill, both of which
+compare it in micros. The `Us` suffix is the only marker, so treating it as
+milliseconds silently reads a timestamp a thousand times too large.
 
 ## Withdrawals (ADR 0033)
 
@@ -75,9 +79,20 @@ const token = bridgeTokenFor(config, NATIVE_USD_ADDRESS)!;
 // Size it against the token's own rules before signing.
 const amount = maxWithdrawable(balances.withdrawableCash, token);
 const rejection = checkWithdrawAmount(amount, token); // undefined = admissible
+if (rejection) return render(rejection); // e.g. a balance below the token's minimum
 
-await wallet.submit(buildClobWithdraw({ token: token.podToken, recipient, amount }));
+await wallet.submit(buildClobWithdraw({
+  token: token.podToken,
+  recipient,
+  amount,
+  // Required: admission refuses a deadline that is not a multiple of it.
+  auctionIntervalUs: market.auctionIntervalMs * 1000,
+}));
 ```
+
+The rejection is checked rather than merely computed, because `maxWithdrawable`
+returns `0n` for a balance below the token's minimum — so an unguarded path
+submits an amount the node is certain to refuse.
 
 `checkWithdrawAmount` returns a discriminated rejection (`{ code, … }`, each
 variant carrying only the numbers its message needs) rather than a sentence — the

--- a/ts-sdk/README.md
+++ b/ts-sdk/README.md
@@ -51,12 +51,89 @@ const ob = useSyncExternalStore(
 - **Layer 2 (resources):** `client.status`, `.markets`, `.market(id)`,
   `.orderbook(id,{depth})`, `.positions(account)`, `.triggers(account)`,
   `.backstopTransfers(account)`, `.candles(id, resolution, range)` (a
-  `SeriesResource` with `setWindow`/`loadOlder`), `.orders(account, query)`.
+  `SeriesResource` with `setWindow`/`loadOlder`), `.orders(account, query)`,
+  `.bridgeConfig`, `.withdrawals(account)`.
 - **Charting:** `createPodDatafeed(client)` returns an `IDatafeedChartApi`-shaped
   object for the TradingView Charting Library (framework-agnostic, no React).
 
 All monetary values are `bigint` (1e18-scaled; use `formatAmount`/`toNumber`/
 `parseAmount`); all timestamps are millisecond `number`s.
+
+## Withdrawals (ADR 0033)
+
+`Clob.withdraw` moves a CLOB balance straight to the claim chain in **one**
+transaction — nothing is credited to a pod account on the way, so there is no
+second signature and no half-finished state to recover.
+
+```ts
+import { buildClobWithdraw, NATIVE_USD_ADDRESS } from "@pod-network/trade-sdk/write";
+import { bridgeTokenFor, checkWithdrawAmount, maxWithdrawable } from "@pod-network/trade-sdk";
+
+const config = await client.bridgeConfig.ready();
+const token = bridgeTokenFor(config, NATIVE_USD_ADDRESS)!;
+
+// Size it against the token's own rules before signing.
+const amount = maxWithdrawable(balances.withdrawableCash, token);
+const rejection = checkWithdrawAmount(amount, token); // undefined = admissible
+
+await wallet.submit(buildClobWithdraw({ token: token.podToken, recipient, amount }));
+```
+
+`checkWithdrawAmount` returns a discriminated rejection (`{ code, … }`, each
+variant carrying only the numbers its message needs) rather than a sentence — the
+wording belongs to whatever renders it.
+
+**`amount` stays in pod's 18 decimals but must be a whole number of claim-chain
+units.** Whatever decimals the token uses on the claim chain become the
+withdrawal granularity on pod, and the config's `min`/`max` are in those decimals
+too — so where native USD maps to 6-decimal USDC, every withdrawal must be a
+multiple of 1e12 wei. `maxWithdrawable` handles both; the builder deliberately
+does no rounding of its own, because silently changing a signed amount is worse
+than a clear rejection.
+
+Track the outcome on `client.withdrawals(account)` (live, REST-backfilled),
+matching on the id derived above. `error` is the **only** place a failure reason
+exists: both `insufficient_balance` and `not_included` produce no L1 event at
+all, so a client watching only the claim chain waits forever.
+
+To confirm the funds actually landed, `waitForClaim({ restUrl, claimRpcUrl,
+withdrawalId, bridge })` reads the withdrawal's claim state from pod and then
+watches the claim chain for the bridge's `Claim` event carrying its hash. It
+settles as `claimed` (with the L1 transaction), `refused` (rejected at execution
+— nothing was debited, so the user can resubmit), or `pending` (timed out or
+aborted, still in flight). Pass a `signal` to stop it.
+
+Two things it handles that are easy to get wrong alone: the claim hash is
+**fetched, never recomputed** — it folds in the pod chain id and the bridge
+version, so a local copy silently stops matching after a version bump — and
+`pending` is not `refused`, so a certificate that is merely still assembling
+never reads as a dead withdrawal. Note `refused` is named for the *burn*, not for
+claimability: it means nothing left the CLOB balance.
+
+**Following more than one, use `watchClaims`.** `waitForClaim` is one loop per
+withdrawal, and a UI tracking several pays that many times over. `watchClaims`
+takes the same options minus the id, hands back `{ add, size, stop }`, and
+reports each outcome through `onSettled` as it happens:
+
+```ts
+const claims = watchClaims({ restUrl, claimRpcUrl, bridge, onSettled: announce });
+claims.add(withdrawalId, { lookbackBlocks: 200 });
+```
+
+The claim-chain half then costs the same whether one withdrawal is outstanding
+or twenty, because a `Claim` topic filter is an OR set at `topics[1]` and one
+`eth_getLogs` covers every hash. Stage 1 is still a REST read per unresolved id,
+issued concurrently, so it is the log scan that stops scaling — not every request.
+
+Each withdrawal keeps its **own** scan floor and the shared query starts at the
+oldest of them, which is the one thing worth knowing when using it. A withdrawal
+still waiting for its certificate contributes no hash to the query, but the
+blocks passing meanwhile are exactly where its `Claim` may land — a relayer can
+claim from a certificate this node has not finished assembling. So a floor is
+raised only for an id whose hash was actually in the query that covered it.
+`add` is idempotent while a withdrawal is outstanding but not after it settles —
+the watcher forgets settled ids, so not re-announcing an outcome you already
+acted on stays with the caller.
 
 ## How caching / low traffic works
 

--- a/ts-sdk/package-lock.json
+++ b/ts-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pod-network/trade-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pod-network/trade-sdk",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.21.0"

--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-network/trade-sdk",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Read/stream TypeScript SDK for the pod trading indexer: cacheable REST seeds + one multiplexed WebSocket, kept in memory. Framework-agnostic.",
   "type": "module",
   "sideEffects": false,

--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -1,14 +1,16 @@
 import type {
-  Address, BackstopTransfer, Balances, LeaderboardPage, LeaderboardQuery, Market, MarketId,
-  PositionsSnapshot, Resolution, Status, TimeRange, Trigger, TriggersQuery, TxExplorer, OrdersQuery,
+  Address, BackstopTransfer, Balances, BridgeConfig, LeaderboardPage, LeaderboardQuery, Market,
+  MarketId, PositionsSnapshot, Resolution, Status, TimeRange, Trigger, TriggersQuery, TxExplorer,
+  OrdersQuery, Withdrawal,
 } from "./types/public.js";
 import { PodRestClient } from "./transport/rest.js";
 import { PodWsClient, type WebSocketCtor } from "./transport/ws.js";
 import { BaseResource, combineResources, derivedResource, type Resource } from "./stores/resource.js";
 import {
-  balancesSource, marketsSource, orderbookSource, positionsSource, statusSource, triggersSource,
-  type MarketsCache, type SyncContext,
+  balancesSource, bridgeConfigSource, marketsSource, orderbookSource, positionsSource,
+  statusSource, triggersSource, type MarketsCache, type SyncContext,
 } from "./sync/sources.js";
+import { withdrawalsSource } from "./sync/withdrawals.js";
 import { CandleSeries } from "./sync/candles.js";
 import { OrderHistory } from "./sync/orders.js";
 import { enrichPositions } from "./sync/positions-live.js";
@@ -175,6 +177,32 @@ export class PodTradeClient {
   balances(account: Address): Resource<Balances> {
     return this.memo(`balances:${account}`, () =>
       new BaseResource(balancesSource(this.ctx, account)),
+    );
+  }
+
+  /**
+   * Static bridge config: the claim chain, and each bridged token's L1 address,
+   * decimals and withdraw window (ADR 0033 §5). Everything a client needs to
+   * build an admissible withdrawal — see `maxWithdrawable` / `checkWithdrawAmount`.
+   *
+   * Re-seeded on reconnect rather than fetched once: an operator can change the
+   * token set or the limits under a long-lived tab, and a stale window would
+   * quietly offer amounts the node now refuses.
+   */
+  get bridgeConfig(): Resource<BridgeConfig> {
+    return this.memo("bridgeConfig", () => new BaseResource(bridgeConfigSource(this.ctx)));
+  }
+
+  /**
+   * This account's terminal withdrawal outcomes, newest first — live off
+   * `pod_withdrawals`, gap-filled over REST on every reconnect.
+   *
+   * Scoped to the **debited** account, which is the master for a delegated
+   * withdrawal, so pass the master address rather than the session key.
+   */
+  withdrawals(account: Address): Resource<Withdrawal[]> {
+    return this.memo(`withdrawals:${account}`, () =>
+      new BaseResource(withdrawalsSource(this.ctx, account)),
     );
   }
 

--- a/ts-sdk/src/codec/bridge.test.ts
+++ b/ts-sdk/src/codec/bridge.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  bridgeTokenFor, checkWithdrawAmount, maxWithdrawable,
+  quantizeWithdrawAmount, toClaimAmount, toPodAmount, withdrawStep,
+} from "./bridge.js";
+import type { Address, BridgeToken } from "../types/public.js";
+
+const POD_USDC = "0x1111111111111111111111111111111111111111" as Address;
+const L1_USDC = "0x2222222222222222222222222222222222222222" as Address;
+const UNBRIDGED = "0x9999999999999999999999999999999999999999" as Address;
+
+const E18 = 1_000_000_000_000_000_000n;
+
+/** 6-decimal token, min 1 USDC, max 1000 USDC — the devnet native-USD mapping. */
+const usdc: BridgeToken = {
+  podToken: POD_USDC,
+  l1Token: L1_USDC,
+  decimals: 6,
+  min: 1_000_000n,
+  max: 1_000_000_000n,
+};
+
+const eighteen: BridgeToken = { ...usdc, decimals: 18, min: 1n, max: 2n ** 255n };
+
+describe("decimal conversion", () => {
+  it("scales an 18-decimal amount down to the claim chain's decimals", () => {
+    expect(toClaimAmount(E18, 6)).toBe(1_000_000n);
+  });
+
+  it("round-trips back to 18 decimals", () => {
+    expect(toPodAmount(toClaimAmount(E18, 6), 6)).toBe(E18);
+  });
+
+  it("is the identity for an 18-decimal token", () => {
+    expect(toClaimAmount(7n, 18)).toBe(7n);
+    expect(toPodAmount(7n, 18)).toBe(7n);
+  });
+
+  // The node multiplies up rather than erroring (WithdrawRules Ordering::Greater),
+  // so a token finer than pod's 18 is always exactly representable.
+  it("scales up for a token with more decimals than pod", () => {
+    expect(toClaimAmount(3n, 20)).toBe(300n);
+    expect(toPodAmount(300n, 20)).toBe(3n);
+  });
+
+  // Truncating here is what produces dust. The node rejects the amount at
+  // admission instead, so this must refuse rather than silently floor —
+  // quantizeWithdrawAmount is the explicit way to round down.
+  it("refuses an amount that is not a whole number of claim-chain units", () => {
+    expect(() => toClaimAmount(E18 + 1n, 6)).toThrow(/not exactly representable/);
+  });
+});
+
+describe("quantization", () => {
+  it("reports the step an amount must be a multiple of", () => {
+    expect(withdrawStep(6)).toBe(1_000_000_000_000n); // 1e12
+    expect(withdrawStep(18)).toBe(1n);
+    expect(withdrawStep(20)).toBe(1n);
+  });
+
+  it("floors to the nearest whole claim-chain unit", () => {
+    expect(quantizeWithdrawAmount(E18 + 1n, 6)).toBe(E18);
+    expect(quantizeWithdrawAmount(E18 - 1n, 6)).toBe(E18 - withdrawStep(6));
+  });
+
+  it("never returns a negative amount", () => {
+    expect(quantizeWithdrawAmount(-5n, 6)).toBe(0n);
+  });
+});
+
+describe("maxWithdrawable", () => {
+  // The devnet trap: pod's native balance maps to 6-decimal L1 USDC, so a MAX
+  // that keeps 18 decimals of precision produces an amount admission refuses.
+  it("floors a ragged balance to a whole number of claim-chain units", () => {
+    const balance = E18 + 123_456_789n; // 1.000000000123456789
+    const max = maxWithdrawable(balance, usdc);
+    expect(max).toBe(E18);
+    expect(max % withdrawStep(usdc.decimals)).toBe(0n);
+  });
+
+  it("clamps to the token's maximum, in claim decimals", () => {
+    expect(maxWithdrawable(5_000n * E18, usdc)).toBe(1_000n * E18);
+  });
+
+  it("is zero when the balance cannot clear the minimum", () => {
+    expect(maxWithdrawable(E18 / 2n, usdc)).toBe(0n);
+  });
+
+  it("is zero for an empty or negative balance", () => {
+    expect(maxWithdrawable(0n, usdc)).toBe(0n);
+    expect(maxWithdrawable(-1n, usdc)).toBe(0n);
+  });
+
+  it("passes an 18-decimal balance through untouched", () => {
+    expect(maxWithdrawable(7n, eighteen)).toBe(7n);
+  });
+
+  // A result that isn't itself admissible would make MAX a button that always
+  // fails — the one amount the UI offers must survive the node's own check.
+  it("always yields an admissible amount", () => {
+    for (const balance of [E18, 5_000n * E18, E18 + 999n, 3n * E18 + 1n]) {
+      expect(checkWithdrawAmount(maxWithdrawable(balance, usdc), usdc)).toBeUndefined();
+    }
+  });
+});
+
+describe("checkWithdrawAmount", () => {
+  it("accepts an exact amount inside the window", () => {
+    expect(checkWithdrawAmount(E18, usdc)).toBeUndefined();
+  });
+
+  it("names a token with no bridge config", () => {
+    expect(checkWithdrawAmount(E18, undefined)?.code).toBe("not_bridged");
+  });
+
+  it("names an amount below the minimum", () => {
+    expect(checkWithdrawAmount(E18 / 2n, usdc)).toEqual({ code: "below_min", decimals: 6, bound: usdc.min });
+  });
+
+  it("names an amount above the maximum", () => {
+    expect(checkWithdrawAmount(2_000n * E18, usdc)).toEqual({ code: "above_max", decimals: 6, bound: usdc.max });
+  });
+
+  it("names an amount that is not exactly representable", () => {
+    expect(checkWithdrawAmount(E18 + 1n, usdc)).toEqual({ code: "not_representable", decimals: 6, step: 10n ** 12n });
+  });
+
+  it("rejects a zero or negative amount", () => {
+    expect(checkWithdrawAmount(0n, usdc)?.code).toBe("non_positive");
+    expect(checkWithdrawAmount(-E18, usdc)?.code).toBe("non_positive");
+  });
+});
+
+describe("bridgeTokenFor", () => {
+  const config = { claimChainId: 42161, sourceContract: L1_USDC, version: 3, tokens: [usdc] };
+
+  it("finds a token by its pod address", () => {
+    expect(bridgeTokenFor(config, POD_USDC)).toEqual(usdc);
+  });
+
+  // The wire serves lowercase addresses while callers hold checksummed ones;
+  // a case-sensitive compare would silently report every token as unbridged.
+  it("ignores address casing", () => {
+    expect(bridgeTokenFor(config, POD_USDC.toUpperCase().replace("0X", "0x") as Address)).toEqual(usdc);
+  });
+
+  it("returns undefined for an unbridged token", () => {
+    expect(bridgeTokenFor(config, UNBRIDGED)).toBeUndefined();
+  });
+
+  it("returns undefined before the config has loaded", () => {
+    expect(bridgeTokenFor(undefined, POD_USDC)).toBeUndefined();
+  });
+});

--- a/ts-sdk/src/codec/bridge.ts
+++ b/ts-sdk/src/codec/bridge.ts
@@ -1,0 +1,138 @@
+// Withdrawal amount arithmetic (ADR 0033 §2), mirroring the node's
+// `WithdrawRules::check_clob_withdraw`.
+//
+// A CLOB withdrawal's `amount` is in pod's 18 decimals, but it settles on the
+// claim chain in that token's decimals — so it has to be a WHOLE number of
+// claim-chain units. The node rejects a remainder at admission rather than
+// truncating it, which removes dust by construction; these helpers exist so a
+// client never offers an amount that will be refused.
+//
+// The case that bites: pod's native USD maps to 6-decimal L1 USDC on devnet, so
+// every native withdrawal must be a multiple of 1e12 wei and the per-token
+// `min`/`max` from `/v1/bridge/config` are in those 6 decimals, not 18. A MAX
+// button that keeps 18 decimals of precision produces amounts the node refuses.
+
+import type { Address, BridgeConfig, BridgeToken } from "../types/public.js";
+import { WAD_DECIMALS } from "./units.js";
+
+/**
+ * The 18-decimal step a withdrawal of this token must be a multiple of:
+ * `10^(18 − decimals)`, or 1 for a token at least as fine as pod (which can
+ * represent every 18-decimal amount, so nothing is quantized away).
+ */
+export function withdrawStep(decimals: number): bigint {
+  return decimals >= WAD_DECIMALS ? 1n : 10n ** BigInt(WAD_DECIMALS - decimals);
+}
+
+/** Floor an 18-decimal amount to a whole number of claim-chain units. Never negative. */
+export function quantizeWithdrawAmount(amount: bigint, decimals: number): bigint {
+  if (amount <= 0n) return 0n;
+  const step = withdrawStep(decimals);
+  return (amount / step) * step;
+}
+
+/**
+ * Pod's 18 decimals → the token's claim-chain decimals: what the L1 `claim` call
+ * carries and what the claim hash commits to.
+ *
+ * Throws on a remainder rather than truncating, matching the node's admission
+ * check — silently flooring here is exactly the dust this design avoids. Use
+ * {@link quantizeWithdrawAmount} when rounding down is what you want.
+ */
+export function toClaimAmount(amount: bigint, decimals: number): bigint {
+  if (decimals > WAD_DECIMALS) return amount * 10n ** BigInt(decimals - WAD_DECIMALS);
+  const step = withdrawStep(decimals);
+  const remainder = amount % step;
+  if (remainder !== 0n) {
+    throw new Error(
+      `withdraw amount ${amount} is not exactly representable in ${decimals} decimals ` +
+      `(remainder ${remainder}); use a multiple of ${step}`,
+    );
+  }
+  return amount / step;
+}
+
+/**
+ * The claim chain's decimals → pod's 18. Exact by construction: only amounts
+ * that were a whole number of claim-chain units are ever admitted, so scaling
+ * back up recovers the original.
+ */
+export function toPodAmount(claimAmount: bigint, decimals: number): bigint {
+  if (decimals > WAD_DECIMALS) return claimAmount / 10n ** BigInt(decimals - WAD_DECIMALS);
+  return claimAmount * withdrawStep(decimals);
+}
+
+/**
+ * The largest amount of `balance` that this token's rules actually admit, in
+ * pod's 18 decimals: quantized down to a whole claim-chain unit, then clamped
+ * into `[min, max]` — which are in claim decimals, so the clamp has to happen
+ * after the conversion, not before.
+ *
+ * `0n` when the balance cannot clear `min`, which is the honest answer: there is
+ * no admissible withdrawal at all, and MAX should be disabled rather than
+ * offering an amount the node refuses.
+ */
+export function maxWithdrawable(balance: bigint, token: BridgeToken): bigint {
+  if (balance <= 0n) return 0n;
+  const claim = toClaimAmount(quantizeWithdrawAmount(balance, token.decimals), token.decimals);
+  if (claim < token.min) return 0n;
+  return toPodAmount(claim > token.max ? token.max : claim, token.decimals);
+}
+
+/**
+ * Why the node would refuse a withdrawal, as a code plus the numbers behind it.
+ *
+ * A code rather than a sentence: this is a published, framework-agnostic
+ * package, so the wording belongs to the consumer that renders it — the same
+ * way `WithdrawalError` is a code the app turns into words. Each variant carries
+ * exactly the numbers its message needs, so a renderer quotes the real bound
+ * without re-deriving it and without defaulting fields that cannot be absent.
+ */
+export type WithdrawRejection =
+  /** The token is not in the bridge's set, so it has no claim chain at all. */
+  | { code: "not_bridged" }
+  | { code: "non_positive"; decimals: number }
+  /** `step` is the 18-decimal multiple the amount must be of. */
+  | { code: "not_representable"; decimals: number; step: bigint }
+  /** `bound` is the limit that was crossed, in claim-chain decimals. */
+  | { code: "below_min" | "above_max"; decimals: number; bound: bigint };
+
+/**
+ * Why the node would refuse this 18-decimal withdrawal, or `undefined` when it
+ * is admissible — the same checks `WithdrawRules::check_clob_withdraw` runs, so
+ * a client can disable the button and say why instead of discovering it from a
+ * revert.
+ *
+ * Mirroring the node's rules is deliberate and unlike the claim hash, which the
+ * ADR insists on fetching: the values here (`decimals`, `min`, `max`) all come
+ * from `/v1/bridge/config`, so only the rule *shape* could drift, and a client
+ * has to predict admissibility anyway to render MAX and enable the button.
+ *
+ * A missing `token` is itself a refusal: with no bridge configured for it there
+ * is no chain for the withdrawal to be claimed on.
+ */
+export function checkWithdrawAmount(
+  amount: bigint,
+  token: BridgeToken | undefined,
+): WithdrawRejection | undefined {
+  if (!token) return { code: "not_bridged" };
+  const { decimals } = token;
+  if (amount <= 0n) return { code: "non_positive", decimals };
+  const step = withdrawStep(decimals);
+  if (amount % step !== 0n) return { code: "not_representable", decimals, step };
+  // Not `amount / step`: a token finer than pod's 18 scales *up*, so the step
+  // is 1 and the division would compare the wrong number against the bounds.
+  const claim = toClaimAmount(amount, decimals);
+  if (claim < token.min) return { code: "below_min", decimals, bound: token.min };
+  if (claim > token.max) return { code: "above_max", decimals, bound: token.max };
+  return undefined;
+}
+
+/** The bridge rules for a pod-side token, or undefined when it isn't bridged. */
+export function bridgeTokenFor(
+  config: BridgeConfig | undefined,
+  podToken: Address,
+): BridgeToken | undefined {
+  const want = podToken.toLowerCase();
+  return config?.tokens.find((t) => t.podToken.toLowerCase() === want);
+}

--- a/ts-sdk/src/codec/decode.ts
+++ b/ts-sdk/src/codec/decode.ts
@@ -2,14 +2,16 @@
 // representations are normalized into bigint + millisecond numbers.
 
 import type {
-  Bar, BackstopTransfer, Balances, LeaderboardEntry, LeaderboardPage, Market, Order,
+  Bar, BackstopTransfer, Balances, BridgeConfig, LeaderboardEntry, LeaderboardPage, Market, Order,
   Orderbook, PartialFill, PerpPosition, Position, PositionsSnapshot, SpotHolding,
   SpotPosition, Status, Trigger, MarketType, OrderDirection, OrderKind, OrderStatus, TriggerType,
+  Withdrawal,
 } from "../types/public.js";
 import type {
-  WireBackstopTransfer, WireBalances, WireCandle, WireLeaderboard, WireMarketDynamics,
-  WireMarketStatic, WireOrder, WireOrderbook, WirePartialFill, WirePerpPosition, WirePosition,
-  WirePositionsSnapshot, WireSpotHolding, WireSpotPosition, WireStatus, WireTrigger,
+  WireBackstopTransfer, WireBalances, WireBridgeConfig, WireCandle, WireLeaderboard,
+  WireMarketDynamics, WireMarketStatic, WireOrder, WireOrderbook, WirePartialFill,
+  WirePerpPosition, WirePosition, WirePositionsSnapshot, WireSpotHolding, WireSpotPosition,
+  WireStatus, WireTrigger, WireWithdrawal,
 } from "../types/wire.js";
 import { dec, decOpt, endMsFromUs, toNumber, usToMs, usToMsOpt } from "./units.js";
 
@@ -274,5 +276,46 @@ export function decodeBackstopTransfer(w: WireBackstopTransfer): BackstopTransfe
     markPrice: dec(w.mark_price),
     equity: dec(w.equity),
     time: usToMs(w.timestamp_us),
+  };
+}
+
+export function decodeBridgeConfig(w: WireBridgeConfig): BridgeConfig {
+  return {
+    claimChainId: w.claim_chain_id,
+    sourceContract: w.source_contract,
+    version: w.version,
+    tokens: w.tokens.map((t) => ({
+      podToken: t.pod_token,
+      l1Token: t.l1_token,
+      decimals: t.decimals,
+      min: dec(t.min),
+      max: dec(t.max),
+    })),
+  };
+}
+
+/**
+ * One withdrawal outcome.
+ *
+ * An unrecognised `error` spelling is carried through **verbatim**, never
+ * dropped. The node's reason enum is extensible and this app ships ahead of the
+ * fleet, so filtering to the spellings this build knows would turn a *failed*
+ * withdrawal into a claimable-looking one: the caller announces that the money
+ * is on its way and then waits for an L1 event that can never fire. Presence is
+ * what carries the meaning here — any reason at all means no claim — so only
+ * presence is decoded, and naming the reason is left to whatever renders it.
+ */
+export function decodeWithdrawal(w: WireWithdrawal): Withdrawal {
+  return {
+    id: w.withdrawal_id,
+    withdrawer: w.withdrawer,
+    to: w.to,
+    token: w.token,
+    amount: dec(w.amount),
+    // `||`, not `??`: an empty string is the wire saying "no reason", and it
+    // would otherwise be a present-but-falsy value that every `if (w.error)`
+    // reads as success while `error !== undefined` reads as failure.
+    error: w.error || undefined,
+    timeUs: w.timestamp_us,
   };
 }

--- a/ts-sdk/src/codec/units.ts
+++ b/ts-sdk/src/codec/units.ts
@@ -2,6 +2,11 @@
 // strings; wire timestamps are microseconds. Public surface uses `bigint`
 // (1e18-scaled) and millisecond `number` timestamps.
 
+// "wad" is the DappHub/MakerDAO name for a fixed-point number carrying 18
+// digits of precision, which is the scale every pod amount is in. Spelled out
+// because the term is only obvious if you have met it before, and code that
+// mixes scales — bridge withdrawals settle in the claim-chain token's decimals,
+// not pod's — reads very differently depending on whether you know that.
 export const WAD = 1_000_000_000_000_000_000n; // 1e18
 export const WAD_DECIMALS = 18;
 

--- a/ts-sdk/src/index.ts
+++ b/ts-sdk/src/index.ts
@@ -47,3 +47,19 @@ export {
 export {
   RESOLUTION_SECONDS, RESOLUTION_PAGE_BUCKETS, RESOLUTIONS, isResolution,
 } from "./codec/resolution.js";
+
+// Withdrawal amount arithmetic (ADR 0033). Read-side, so a UI can size and
+// validate a withdrawal without pulling the signing entry.
+export {
+  withdrawStep, quantizeWithdrawAmount, toClaimAmount, toPodAmount,
+  maxWithdrawable, checkWithdrawAmount, type WithdrawRejection, bridgeTokenFor,
+} from "./codec/bridge.js";
+// Following a withdrawal onto the claim chain.
+export {
+  fetchClaimStatus, waitForClaim, watchClaims, CLAIM_TOPIC,
+  type ClaimStatus, type ClaimOutcome, type WaitForClaimOptions,
+  type ClaimWatcher, type WatchClaimsOptions,
+} from "./transport/claim.js";
+// Only the options type: `WaitForClaimOptions` extends it, so declaration emit
+// needs it public. The functions themselves stay internal.
+export type { RpcOptions } from "./transport/jsonrpc.js";

--- a/ts-sdk/src/sync/sources.ts
+++ b/ts-sdk/src/sync/sources.ts
@@ -14,7 +14,7 @@
 //    REST re-seed via `onError` when `since` is too old (down too long).
 
 import type {
-  Address, Balances, Market, MarketId, Orderbook, PositionsSnapshot, Status, Trigger,
+  Address, Balances, BridgeConfig, Market, MarketId, Orderbook, PositionsSnapshot, Status, Trigger,
 } from "../types/public.js";
 import type {
   WireMarketDynamics, WireOrderbook, WirePositionsPush, WireTriggersPush,
@@ -80,6 +80,21 @@ export function statusSource({ rest, ws }: SyncContext): ResourceSource<Status> 
     let alive = true;
     const seed = () => { rest.status().then((s) => { if (alive) h.set(s); }).catch((e) => h.fail(e)); };
     const off = seedNowAndOnReconnect(ws, seed);
+    return () => { alive = false; off(); };
+  };
+}
+
+/** Static bridge config (ADR 0033 §5). Re-seeded on reconnect because an
+ * operator can change the token set or the withdraw limits under a long-lived
+ * tab, and a stale window would offer amounts the node now refuses. */
+export function bridgeConfigSource({ rest, ws }: SyncContext): ResourceSource<BridgeConfig> {
+  return (h) => {
+    let alive = true;
+    const off = seedNowAndOnReconnect(ws, () => {
+      rest.bridgeConfig()
+        .then((c) => { if (alive) h.set(c); })
+        .catch((e) => { if (!h.current()) h.fail(e as Error); });
+    });
     return () => { alive = false; off(); };
   };
 }

--- a/ts-sdk/src/sync/withdrawals.test.ts
+++ b/ts-sdk/src/sync/withdrawals.test.ts
@@ -1,0 +1,257 @@
+// The withdrawals resource: REST backfill + live stream merged into one list.
+//
+// Worth pinning because none of it is reachable from `typecheck`: the paging
+// cursor, the dedupe between the two surfaces, and the ordering are all runtime
+// behaviour over data that type-checks either way.
+
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+
+import { withdrawalsSource } from "./withdrawals.js";
+import { BaseResource } from "../stores/resource.js";
+import { PodWsClient, type WebSocketCtor } from "../transport/ws.js";
+import type { PodRestClient } from "../transport/rest.js";
+import type { SyncContext } from "./sources.js";
+import type { Address, Hash, Withdrawal, WithdrawalsQuery } from "../types/public.js";
+import type { WireWithdrawal } from "../types/wire.js";
+
+type Json = Record<string, unknown>;
+
+const ACCOUNT = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Address;
+const TO = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as Address;
+const TOKEN = "0xcccccccccccccccccccccccccccccccccccccccc" as Address;
+
+class FakeSocket {
+  static last: FakeSocket | undefined;
+  sent: Json[] = [];
+  onopen?: () => void;
+  onmessage?: (ev: { data: string }) => void;
+  onclose?: () => void;
+  constructor(_url: string) {
+    FakeSocket.last = this;
+    setTimeout(() => this.onopen?.(), 0);
+  }
+  send(raw: string): void { this.sent.push(JSON.parse(raw) as Json); }
+  close(): void { this.onclose?.(); }
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const id = (n: number) => `0x${n.toString(16).padStart(64, "0")}` as Hash;
+
+const outcome = (n: number, timeUs: number): Withdrawal => ({
+  id: id(n),
+  withdrawer: ACCOUNT,
+  to: TO,
+  token: TOKEN,
+  amount: 1_000_000_000_000_000_000n,
+  timeUs,
+});
+
+/** The wire form of an outcome, as `pod_withdrawals` pushes it. */
+const wire = (n: number, timeUs: number): WireWithdrawal => ({
+  withdrawal_id: id(n),
+  withdrawer: ACCOUNT,
+  to: TO,
+  token: TOKEN,
+  amount: "0xde0b6b3a7640000", // 1e18
+  timestamp_us: timeUs,
+});
+
+/**
+ * A started resource over a scripted REST backend. `pages` is consumed one call
+ * at a time, so a test can describe a multi-page backfill; `calls` records the
+ * cursor each call was made with.
+ */
+async function started(pages: Withdrawal[][]) {
+  const calls: WithdrawalsQuery[] = [];
+  const remaining = [...pages];
+  const rest = {
+    bridgeWithdrawals: vi.fn(async (_account?: Address, q?: WithdrawalsQuery) => {
+      calls.push(q ?? {});
+      return remaining.shift() ?? [];
+    }),
+  } as unknown as PodRestClient;
+
+  const ws = new PodWsClient({
+    wsUrl: "ws://test",
+    WebSocket: FakeSocket as unknown as WebSocketCtor,
+    idleTimeoutMs: 60 * 60_000,
+  });
+  onTestFinished(() => ws.close());
+
+  const ctx = { rest, ws, positionResyncMs: 0, marketResyncMs: 0 } as SyncContext;
+  const resource = new BaseResource(withdrawalsSource(ctx, ACCOUNT));
+  onTestFinished(() => resource.destroy());
+  resource.subscribe(() => {});
+  await flush();
+  await flush();
+
+  /** Deliver a `pod_withdrawals` frame the way the server would. */
+  const push = async (items: ReturnType<typeof wire>[]) => {
+    const socket = FakeSocket.last!;
+    const req = socket.sent.find((m) => m.method === "eth_subscribe");
+    const subId = "0xsub1";
+    socket.onmessage?.({
+      data: JSON.stringify({ jsonrpc: "2.0", id: req?.id, result: subId }),
+    });
+    await flush();
+    socket.onmessage?.({
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "eth_subscription",
+        params: { subscription: subId, result: items },
+      }),
+    });
+    await flush();
+  };
+
+  return { resource, calls, rest, push };
+}
+
+describe("withdrawalsSource", () => {
+  it("seeds from REST without waiting for the socket", async () => {
+    const { resource } = await started([[outcome(1, 5_000)]]);
+    expect(resource.get()?.map((w) => w.id)).toEqual([id(1)]);
+  });
+
+  // Live-only, with no `since`. This is a replay channel: the server accepts a
+  // cursor only while its buffer still reaches back that far, and `since: 0`
+  // never does — sending it would fail every subscribe and spend the retry
+  // budget on a self-inflicted rejection. History comes from REST regardless.
+  it("subscribes live-only until a real cursor exists", async () => {
+    await started([[]]);
+    const req = FakeSocket.last!.sent.find((m) => m.method === "eth_subscribe");
+    expect(req?.params).toEqual(["pod_withdrawals", { account: ACCOUNT }]);
+  });
+
+  // An account with no withdrawals still has to reach a defined empty list. Left
+  // undefined, every consumer stays on "not loaded yet" and mistakes the first
+  // live outcome for its initial snapshot — swallowing a first-ever withdrawal.
+  it("publishes an empty list when there is no history", async () => {
+    const { resource } = await started([[]]);
+    expect(resource.get()).toEqual([]);
+  });
+
+  // The paging cursor must be local to the run: a live push moves the shared one,
+  // and a page issued after that would start past the rest of an older tick —
+  // rows the forward-only cursor could never return for.
+  it("keeps paging an older tick after a live push moves the shared cursor", async () => {
+    const full = Array.from({ length: 500 }, (_, i) => outcome(i + 1, 5_000));
+    const { calls, push } = await started([full, [outcome(501, 5_000)]]);
+    await push([wire(900, 9_000)]); // newer tick arrives mid-backfill
+    expect(calls[1]).toEqual({ since: 5_000, sinceId: id(500), limit: 500 });
+  });
+
+  // A tick can hold more outcomes than one page, so paging on the deadline alone
+  // would re-serve the tick's earlier rows or skip its later ones. The cursor is
+  // (since, since_id) and the second call has to carry both.
+  it("pages a full response using the mid-tick cursor", async () => {
+    const full = Array.from({ length: 500 }, (_, i) => outcome(i + 1, 5_000));
+    const { resource, calls } = await started([full, [outcome(501, 9_000)]]);
+
+    expect(calls[0]).toEqual({ since: 0, sinceId: undefined, limit: 500 });
+    expect(calls[1]).toEqual({ since: 5_000, sinceId: id(500), limit: 500 });
+    expect(resource.get()).toHaveLength(501);
+  });
+
+  // A short page means the log is exhausted, so the pass stops there. The second
+  // call is the re-seed the socket's `open` triggers (the same cold-start
+  // duplicate `seedNowAndOnReconnect` documents) — and it resumes from the
+  // advanced cursor rather than replaying from the start.
+  it("stops paging on a short page and resumes from the cursor", async () => {
+    const { calls } = await started([[outcome(1, 5_000)]]);
+    expect(calls[0]).toEqual({ since: 0, sinceId: undefined, limit: 500 });
+    expect(calls[1]).toEqual({ since: 5_000, sinceId: id(1), limit: 500 });
+  });
+
+  // The same outcome can arrive on both surfaces — a reconnect backfill overlaps
+  // whatever the stream already delivered. Terminal outcomes are immutable, so
+  // the merge is by id and the duplicate must vanish rather than double up.
+  it("dedupes an outcome delivered by both REST and the stream", async () => {
+    const { resource, push } = await started([[outcome(1, 5_000)]]);
+    await push([wire(1, 5_000)]);
+    expect(resource.get()?.map((w) => w.id)).toEqual([id(1)]);
+  });
+
+  it("merges live outcomes newest-first", async () => {
+    const { resource, push } = await started([[outcome(1, 5_000)]]);
+    await push([wire(2, 9_000), wire(3, 7_000)]);
+    expect(resource.get()?.map((w) => w.id)).toEqual([id(2), id(3), id(1)]);
+  });
+
+  it("carries a failure reason through from the stream", async () => {
+    const { resource, push } = await started([[]]);
+    await push([{ ...wire(1, 5_000), error: "not_included" }]);
+    expect(resource.get()?.[0]?.error).toBe("not_included");
+  });
+
+  // A backfill that fails while the stream is still feeding a usable list should
+  // not blank the UI — only a resource with nothing at all to show reports it.
+  it("does not fail the resource when it already holds outcomes", async () => {
+    const { resource, push } = await started([[outcome(1, 5_000)]]);
+    await push([wire(2, 9_000)]);
+    expect(resource.error).toBeUndefined();
+    expect(resource.get()).toHaveLength(2);
+  });
+
+  // The app ships ahead of the fleet, so a node that has never heard of this
+  // channel is an expected state, not a bug. Retrying it forever would be a
+  // request every 30s for the life of the tab.
+  it("stops resubscribing after a run of rejections", async () => {
+    vi.useFakeTimers();
+    onTestFinished(() => { vi.useRealTimers(); });
+
+    const rest = { bridgeWithdrawals: vi.fn(async () => []) } as unknown as PodRestClient;
+    const ws = new PodWsClient({
+      wsUrl: "ws://test",
+      WebSocket: FakeSocket as unknown as WebSocketCtor,
+      idleTimeoutMs: 60 * 60_000,
+    });
+    onTestFinished(() => ws.close());
+    const ctx = { rest, ws, positionResyncMs: 0, marketResyncMs: 0 } as SyncContext;
+    const resource = new BaseResource(withdrawalsSource(ctx, ACCOUNT));
+    onTestFinished(() => resource.destroy());
+    resource.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(1); // the socket's deferred open
+
+    const socket = FakeSocket.last!;
+    const subscribes = () => socket.sent.filter((m) => m.method === "eth_subscribe");
+    // Reject whatever subscribe is outstanding, then let the backoff elapse.
+    const rejectPending = async () => {
+      const last = subscribes().at(-1);
+      if (!last) return;
+      socket.onmessage?.({
+        data: JSON.stringify({
+          jsonrpc: "2.0",
+          id: last.id,
+          error: { code: -32000, message: "since is older than the replay buffer" },
+        }),
+      });
+      await vi.advanceTimersByTimeAsync(60_000); // past the capped 30s backoff
+    };
+
+    for (let i = 0; i < 12; i++) await rejectPending();
+    // The initial subscribe plus at most MAX_SUB_RETRIES retries.
+    expect(subscribes()).toHaveLength(6);
+  });
+
+  // The node's reason enum is extensible and this app ships ahead of the fleet,
+  // so a spelling this build predates is expected rather than exceptional. It
+  // has to survive the decode: filtering to known spellings turns a FAILED
+  // withdrawal into a claimable-looking one, and the consumer then announces the
+  // money is on its way and waits for an L1 event that can never fire.
+  it("keeps a failure reason it has never seen instead of reading it as success", async () => {
+    const { resource, push } = await started([[]]);
+    await push([{ ...wire(1, 5_000), error: "token_not_bridged" }]);
+    expect(resource.get()![0]!.error).toBe("token_not_bridged");
+  });
+
+  // The other direction: an empty string is the wire saying "no reason", and it
+  // must not survive as a present-but-falsy value that `if (w.error)` reads as
+  // success while `error !== undefined` reads as failure.
+  it("treats an empty reason as no reason", async () => {
+    const { resource, push } = await started([[]]);
+    await push([{ ...wire(2, 6_000), error: "" }]);
+    expect(resource.get()![0]!.error).toBeUndefined();
+  });
+});

--- a/ts-sdk/src/sync/withdrawals.test.ts
+++ b/ts-sdk/src/sync/withdrawals.test.ts
@@ -62,13 +62,22 @@ const wire = (n: number, timeUs: number): WireWithdrawal => ({
  * at a time, so a test can describe a multi-page backfill; `calls` records the
  * cursor each call was made with.
  */
-async function started(pages: Withdrawal[][]) {
+async function started(pages: Withdrawal[][], holdCall?: number) {
   const calls: WithdrawalsQuery[] = [];
   const remaining = [...pages];
+  // `holdCall` parks that call's RESPONSE, leaving the walk mid-backfill so a
+  // test can deliver a live frame before the next page's cursor is computed.
+  // Without it the whole walk finishes inside `started`, and a push afterwards
+  // cannot influence a query that was already issued.
+  let release!: () => void;
+  const held = new Promise<void>((resolve) => { release = resolve; });
   const rest = {
     bridgeWithdrawals: vi.fn(async (_account?: Address, q?: WithdrawalsQuery) => {
+      const n = calls.length;
       calls.push(q ?? {});
-      return remaining.shift() ?? [];
+      const rows = remaining.shift() ?? [];
+      if (n === holdCall) await held;
+      return rows;
     }),
   } as unknown as PodRestClient;
 
@@ -105,7 +114,7 @@ async function started(pages: Withdrawal[][]) {
     await flush();
   };
 
-  return { resource, calls, rest, push };
+  return { resource, calls, rest, push, release };
 }
 
 describe("withdrawalsSource", () => {
@@ -137,8 +146,16 @@ describe("withdrawalsSource", () => {
   // rows the forward-only cursor could never return for.
   it("keeps paging an older tick after a live push moves the shared cursor", async () => {
     const full = Array.from({ length: 500 }, (_, i) => outcome(i + 1, 5_000));
-    const { calls, push } = await started([full, [outcome(501, 5_000)]]);
-    await push([wire(900, 9_000)]); // newer tick arrives mid-backfill
+    // Park page 1's response, so the walk is genuinely suspended between pages
+    // when the frame lands. Pushing after a completed walk proves nothing: the
+    // next page's cursor would already have been computed and issued.
+    const { calls, push, release } = await started([full, [outcome(501, 5_000)]], 0);
+    await push([wire(900, 9_000)]); // newer tick arrives MID-backfill
+    release();
+    await flush();
+    await flush();
+    // Page 2 resumes from the run-local cursor, not the shared one the push
+    // advanced to 9_000 — which would skip the rest of the 5_000 tick for good.
     expect(calls[1]).toEqual({ since: 5_000, sinceId: id(500), limit: 500 });
   });
 

--- a/ts-sdk/src/sync/withdrawals.ts
+++ b/ts-sdk/src/sync/withdrawals.ts
@@ -1,0 +1,177 @@
+// Terminal withdrawal outcomes for one account (ADR 0033 §6): seeded and
+// gap-filled over `GET /v1/bridge/withdrawals/{account}`, kept live by the
+// `pod_withdrawals` subscription.
+//
+// The two surfaces serve the identical shape, so a backfilled outcome is
+// indistinguishable from one that arrived live — which is what lets a reconnect
+// be a plain "fetch the gap" rather than a separate code path.
+//
+// Outcomes are terminal and immutable: an id appears once and never changes, so
+// merging is last-write-wins on the id with no reconciliation.
+
+import type { Address, Withdrawal } from "../types/public.js";
+import type { WireWithdrawal } from "../types/wire.js";
+import { decodeWithdrawal } from "../codec/decode.js";
+import type { ResourceSource } from "../stores/resource.js";
+import { seedNowAndOnReconnect, type SyncContext } from "./sources.js";
+
+/** Page size for the backfill. The server caps at 1000 and defaults to 500. */
+const PAGE_LIMIT = 500;
+
+/** Pages to walk in one backfill before giving up, so a bad cursor can't spin
+ * forever. 50 pages × 500 covers 25k outcomes — far past any real account. */
+const MAX_PAGES = 50;
+
+/** Resubscribe attempts after a rejection before leaving the channel alone.
+ * Reached only when the rejection is permanent — see the `onError` comment. */
+const MAX_SUB_RETRIES = 5;
+
+export function withdrawalsSource(
+  { rest, ws }: SyncContext,
+  account: Address,
+): ResourceSource<Withdrawal[]> {
+  return (h) => {
+    let alive = true;
+    const byId = new Map<string, Withdrawal>();
+    // Cursor into the outcome log: the newest tick fully absorbed, plus the last
+    // id seen inside it. Both are needed because one tick can span a page — the
+    // deadline alone can only re-serve the tick's earlier rows or skip its later
+    // ones.
+    let sinceUs = 0;
+    let sinceId: Withdrawal["id"] | undefined;
+    let retries = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const publish = () => {
+      // Newest first: a user reads their most recent withdrawal at the top, and
+      // the id tiebreak keeps a same-tick pair from reordering between renders.
+      h.set([...byId.values()].sort((a, b) => b.timeUs - a.timeUs || b.id.localeCompare(a.id)));
+    };
+
+    const absorb = (items: Withdrawal[]) => {
+      for (const w of items) {
+        byId.set(w.id, w);
+        // Never move the cursor backwards: an out-of-order arrival would
+        // otherwise re-serve ticks we already hold.
+        if (w.timeUs >= sinceUs) { sinceUs = w.timeUs; sinceId = w.id; }
+      }
+    };
+
+    /**
+     * Walk forward from the cursor until the log is exhausted.
+     *
+     * Serialised on `inflight` because two callers race by construction: the
+     * immediate seed and the socket's `open` overlap on a cold start, and a
+     * reconnect can fire while a retry's backfill is still paging. Both share
+     * the cursor, so concurrent loops would re-request each other's pages.
+     */
+    let inflight: Promise<void> | undefined;
+    const backfill = (): Promise<void> => (inflight ??= run().finally(() => { inflight = undefined; }));
+
+    const run = async () => {
+      try {
+        // Page against a cursor local to this run. The shared one is also moved
+        // by live pushes, and a push landing mid-backfill would jump the next
+        // page past the rest of an older tick — rows the forward-only cursor
+        // could then never come back for.
+        let pageSince = sinceUs;
+        let pageSinceId = sinceId;
+        for (let page = 0; page < MAX_PAGES; page++) {
+          const rows = await rest.bridgeWithdrawals(account, {
+            since: pageSince,
+            sinceId: pageSinceId,
+            limit: PAGE_LIMIT,
+          });
+          if (!alive) return;
+          if (rows.length === 0) break;
+          absorb(rows);
+          // Rows come back ascending, so the last one is this page's high-water
+          // mark — regardless of what the stream did to the shared cursor.
+          // Non-empty by the check above.
+          const last = rows[rows.length - 1]!;
+          pageSince = last.timeUs;
+          pageSinceId = last.id;
+          if (rows.length < PAGE_LIMIT) break;
+        }
+        // Once, after paging: publishing per page re-copies and re-sorts
+        // everything accumulated so far for a list the user sees for
+        // milliseconds — O(pages²) on exactly the accounts paging exists for.
+        //
+        // Unconditional, including when nothing was found. An account with no
+        // withdrawals must still reach a defined `[]`, or every consumer stays
+        // on "not loaded yet" and treats the first live outcome as its initial
+        // snapshot — silently swallowing a user's first-ever withdrawal.
+        publish();
+      } catch (e) {
+        // Publish on the failure path too, for exactly the reason the success
+        // path publishes unconditionally: a consumer left on "not loaded yet"
+        // treats the first live outcome as its initial snapshot and swallows it.
+        // A failed backfill is a reason to have no history — not a reason to
+        // misread the next thing that happens. `fail` records the error beside
+        // the value rather than replacing it, so a caller can read both.
+        publish();
+        // Only surface the failure when there is nothing to show; otherwise the
+        // stream is still feeding a usable list and a toast would be noise.
+        if (byId.size === 0) h.fail(e as Error);
+      }
+    };
+
+    const sub = ws.subscribe(
+      "pod_withdrawals",
+      // Live-only until a cursor exists. This is a replay channel, so the server
+      // accepts `since` only when its buffer still reaches back that far — and
+      // `since: 0` never does, so sending it would fail the subscribe every time
+      // and burn the retry budget below on a self-inflicted rejection. (The
+      // `since: 0` idiom belongs to the *state* channels, which answer it with a
+      // snapshot.) REST backfill covers history either way.
+      { account },
+      (result) => {
+        retries = 0;
+        // A frame means the subscription is healthy, so a retry armed by an
+        // earlier rejection has nothing left to fix. Letting it fire would call
+        // `resubscribe()` on a live subscription, which drops the server's id
+        // without an `eth_unsubscribe` and leaks one subscription per occurrence.
+        if (retryTimer) { clearTimeout(retryTimer); retryTimer = undefined; }
+        // One message per tick carrying that tick's outcomes for this account.
+        absorb((result as WireWithdrawal[]).map(decodeWithdrawal));
+        publish();
+        sub.update({ since: sinceUs }); // keep the resume point fresh for a reconnect
+      },
+      () => {
+        // Rejected — usually a `since` older than the replay buffer. Back off,
+        // re-seed over REST (which has no such horizon), and resubscribe; after
+        // a couple of failures drop `since` and settle for live-only.
+        //
+        // Bounded, because the other reason for a rejection is a node that
+        // doesn't serve this channel at all — an older build, since the app
+        // ships ahead of the fleet. Retrying that forever is a request every
+        // 30s for the lifetime of the tab, so give up and leave the REST-seeded
+        // list in place rather than polling a node that will never answer.
+        if (!alive || retries >= MAX_SUB_RETRIES) return;
+        retries++;
+        if (retryTimer) clearTimeout(retryTimer);
+        retryTimer = setTimeout(() => {
+          void backfill().then(() => {
+            if (!alive) return;
+            // Live-only until a real cursor exists (see the subscribe above), and
+            // dropped again after a couple of failures in case the replay buffer
+            // has outrun it.
+            sub.update({ since: retries > 2 || sinceUs === 0 ? undefined : sinceUs });
+            sub.resubscribe();
+          });
+        }, Math.min(30_000, 500 * 2 ** (retries - 1)));
+      },
+    );
+
+    // Seed immediately — REST needs no socket, so history paints without waiting
+    // on the handshake — and fill the gap again on every reconnect.
+    const offOpen = seedNowAndOnReconnect(ws, () => { if (alive) void backfill(); });
+
+    return () => {
+      alive = false;
+      offOpen();
+      if (retryTimer) clearTimeout(retryTimer);
+      sub.unsubscribe();
+    };
+  };
+}

--- a/ts-sdk/src/transport/claim.test.ts
+++ b/ts-sdk/src/transport/claim.test.ts
@@ -132,6 +132,21 @@ describe("fetchClaimStatus", () => {
     expect(await status(detail("claimable", false))).toEqual({ state: "pending" });
   });
 
+  // The forward-compatibility rule, and the one a plausible "simplification"
+  // would break: a status this build has never seen must not veto a certificate
+  // attached to the same response. Gating proof handling on the known statuses
+  // passes every other test in this file, which is why this one exists.
+  it("believes a proof under a status it has never heard of", async () => {
+    expect(await status(detail("settling", true)))
+      .toEqual({ state: "claimable", claimHash: CLAIM_HASH });
+  });
+
+  // And the other half: unfamiliar means "ask again", never terminal — a client
+  // holding burned funds must not be told they are gone by a word it cannot read.
+  it("treats an unfamiliar status with no proof as pending, not terminal", async () => {
+    expect(await status(detail("settling", false))).toEqual({ state: "pending" });
+  });
+
   // No outcome row yet — the normal state right after submitting. Terminality is
   // carried only by `status`, never by an HTTP code.
   it("treats a 404 as pending, not terminal", async () => {

--- a/ts-sdk/src/transport/claim.test.ts
+++ b/ts-sdk/src/transport/claim.test.ts
@@ -1,0 +1,424 @@
+import { describe, expect, it, vi } from "vitest";
+import { toEventSelector } from "viem";
+
+import { CLAIM_TOPIC, fetchClaimStatus, waitForClaim, watchClaims, type ClaimOutcome } from "./claim.js";
+import type { Hash } from "../types/public.js";
+
+const ID = `0x${"11".repeat(32)}` as Hash;
+const CLAIM_HASH = `0x${"22".repeat(32)}` as Hash;
+const L1_TX = `0x${"33".repeat(32)}` as Hash;
+const BRIDGE = "0x4444444444444444444444444444444444444444" as const;
+
+/**
+ * A fetch stand-in over a per-method script. Each method's queue is consumed in
+ * order and its last entry repeats, so a test describes only the transitions it
+ * cares about.
+ */
+function fakeRpc(script: Record<string, unknown[]>) {
+  const queues = Object.fromEntries(Object.entries(script).map(([k, v]) => [k, [...v]]));
+  const calls: Array<{ method: string; params: unknown }> = [];
+  const fetchFn = vi.fn(async (_url: string, init?: { body?: string }) => {
+    const req = JSON.parse(init!.body!) as { method: string; params: unknown[] };
+    calls.push({ method: req.method, params: req.params[0] });
+    const queue = queues[req.method];
+    const next = queue && (queue.length > 1 ? queue.shift() : queue[0]);
+    return {
+      json: async () => {
+        if (next === undefined || next === "error") {
+          return { jsonrpc: "2.0", id: 1, error: { code: -32000, message: "unavailable" } };
+        }
+        const asError = (next as { __error?: string }).__error;
+        if (asError) return { jsonrpc: "2.0", id: 1, error: { code: -32603, message: asError } };
+        return { jsonrpc: "2.0", id: 1, result: next };
+      },
+    } as Response;
+  });
+  return { fetchFn, calls };
+}
+
+const claimLog = { transactionHash: L1_TX, blockNumber: "0x64" };
+
+/** `GET /bridge/withdrawals/by-id/{id}` — `status` is authoritative, and `proof`
+ * is OMITTED rather than null until a certificate exists. */
+const detail = (status: string, withProof = status === "claimable") => ({
+  ok: true,
+  json: async () => ({
+    withdrawal: { withdrawal_id: ID, amount: "0x0", timestamp_us: 1 },
+    status,
+    ...(withProof ? { proof: { claim_hash: CLAIM_HASH } } : {}),
+  }),
+});
+
+/** Serves the REST by-id route from a queue, and JSON-RPC from `fakeRpc`. */
+function fakeAll(details: unknown[], script: Record<string, unknown[]>) {
+  const rpcFake = fakeRpc(script);
+  const queue = [...details];
+  const fetchFn = (async (url: string, init?: { body?: string }) => {
+    if (!init?.body) return (queue.length > 1 ? queue.shift() : queue[0]) as Response;
+    return (rpcFake.fetchFn as unknown as typeof fetch)(url as string, init as RequestInit);
+  }) as unknown as typeof fetch;
+  return { fetchFn, calls: rpcFake.calls };
+}
+
+const wait = (
+  script: Record<string, unknown[]>,
+  extra?: { bridge?: `0x${string}`; details?: unknown[] },
+) => {
+  const { details, ...options } = extra ?? {};
+  const { fetchFn, calls } = fakeAll(details ?? [detail("claimable")], script);
+  const promise = waitForClaim({
+    restUrl: "http://pod/v1",
+    claimRpcUrl: "http://l1",
+    withdrawalId: ID,
+    pollMs: 0,
+    timeoutMs: 1_000,
+    fetch: fetchFn as unknown as typeof fetch,
+    ...options,
+  });
+  return { promise, calls };
+};
+
+describe("CLAIM_TOPIC", () => {
+  // The constant is hand-written so the read path doesn't pull in an ABI
+  // encoder. This is the guard that keeps it honest: if the event signature in
+  // protocol/src/Bridge.sol changes, or the literal is mistyped, this fails.
+  it("is the keccak of the bridge's Claim signature", () => {
+    expect(CLAIM_TOPIC).toBe(
+      toEventSelector("Claim(bytes32,address,address,uint256,address)"),
+    );
+  });
+});
+
+describe("fetchClaimStatus", () => {
+  let urls: string[] = [];
+  const status = async (response: unknown) => {
+    urls = [];
+    return fetchClaimStatus("http://pod/v1", ID, {
+      fetch: (async (url: string) => {
+        urls.push(url);
+        return response;
+      }) as unknown as typeof fetch,
+    });
+  };
+
+  // Nothing type-checks a path string against a Rust router, and this one's
+  // failure mode is the quiet kind. Dropping `by-id` doesn't 404 — it lands on
+  // the three-segment `/bridge/withdrawals/{account}` route with an id in the
+  // account slot, which answers with an empty list. The watch reads that as "no
+  // certificate yet" and polls until it times out, so a wrong URL is
+  // indistinguishable from a withdrawal that never gathered enough signatures.
+  it("requests the four-segment by-id route", async () => {
+    await status(detail("claimable"));
+    expect(urls).toEqual([`http://pod/v1/bridge/withdrawals/by-id/${ID}`]);
+  });
+
+  it("reads claimable off `status`, with the hash from the proof", async () => {
+    expect(await status(detail("claimable"))).toEqual({ state: "claimable", claimHash: CLAIM_HASH });
+  });
+
+  // Terminal, and distinct from pending: refused means nothing was debited, so a
+  // caller stops asking and tells the user they can resubmit.
+  it("reads refused off `status`", async () => {
+    expect(await status(detail("refused"))).toEqual({ state: "refused" });
+  });
+
+  it("reads pending off `status`", async () => {
+    expect(await status(detail("pending"))).toEqual({ state: "pending" });
+  });
+
+  // `proof` is omitted, not null, until a certificate can be assembled — so a
+  // claimable status without one is still pending rather than a crash.
+  it("stays pending when the proof is absent", async () => {
+    expect(await status(detail("claimable", false))).toEqual({ state: "pending" });
+  });
+
+  // No outcome row yet — the normal state right after submitting. Terminality is
+  // carried only by `status`, never by an HTTP code.
+  it("treats a 404 as pending, not terminal", async () => {
+    expect(await status({ ok: false, status: 404, json: async () => ({}) })).toEqual({ state: "pending" });
+  });
+
+  it("treats a transport failure as pending", async () => {
+    const threw = fetchClaimStatus("http://pod/v1", ID, {
+      fetch: (async () => { throw new Error("offline"); }) as unknown as typeof fetch,
+    });
+    expect(await threw).toEqual({ state: "pending" });
+  });
+});
+
+describe("waitForClaim", () => {
+  it("returns the claim transaction once the event appears", async () => {
+    const { promise } = wait({
+      eth_blockNumber: ["0x2710"],
+      eth_getLogs: [[claimLog]],
+    });
+    expect(await promise).toEqual({ state: "claimed", claimHash: CLAIM_HASH, transactionHash: L1_TX });
+  });
+
+  it("gives up terminally on a refused withdrawal, without scanning L1", async () => {
+    const { promise, calls } = wait({ eth_blockNumber: ["0x2710"] }, { details: [detail("refused")] });
+    expect(await promise).toEqual({ state: "refused" });
+    expect(calls.some((c) => c.method === "eth_getLogs")).toBe(false);
+  });
+
+  it("waits for the certificate to assemble before scanning", async () => {
+    const { promise } = wait(
+      { eth_blockNumber: ["0x2710"], eth_getLogs: [[claimLog]] },
+      { details: [detail("pending"), detail("claimable")] },
+    );
+    expect(await promise).toEqual({ state: "claimed", claimHash: CLAIM_HASH, transactionHash: L1_TX });
+  });
+
+  // The window is bounded on both ends: it starts a lookback before the current
+  // block (an unbounded eth_getLogs is refused or throttled by most endpoints),
+  // and it never re-scans a range that already came back clean.
+  //
+  // Crucially the scan names its own `toBlock` and resumes from exactly that.
+  // With `toBlock: "latest"` the node picks the end itself, and any block mined
+  // between that choice and a later head read is stepped over for good — which
+  // on a 250ms-block chain loses the claim outright a few percent of the time.
+  it("scans a closed range and resumes from its own upper bound", async () => {
+    const { promise, calls } = wait({
+      // Head advances between polls; the second value is read before the second
+      // scan, so a correct implementation never leaves a gap between them.
+      eth_blockNumber: ["0x2710", "0x2720"],
+      eth_getLogs: [[], [claimLog]],
+    });
+    await promise;
+    const scans = calls.filter((c) => c.method === "eth_getLogs")
+      .map((c) => c.params as { fromBlock: string; toBlock: string });
+    expect(scans[0]?.fromBlock).toBe(`0x${(0x2710 - 5000).toString(16)}`); // tip − lookback
+    expect(scans[0]?.toBlock).toBe("0x2710"); // pinned, not "latest"
+    expect(scans[1]?.fromBlock).toBe("0x2711"); // exactly one past scan 1's end — no gap
+  });
+
+  // A failed query is indistinguishable from an empty one at the call site, so
+  // advancing on it would skip the range unread — and the lookback window is
+  // precisely the one covering a relayer that claimed before the watch began.
+  it("does not advance past a range whose query failed", async () => {
+    const { promise, calls } = wait({
+      eth_blockNumber: ["0x2710"],
+      eth_getLogs: ["error", [claimLog]],
+    });
+    await promise;
+    const scans = calls.filter((c) => c.method === "eth_getLogs")
+      .map((c) => (c.params as { fromBlock: string }).fromBlock);
+    expect(scans[1]).toBe(scans[0]); // retried the same range, not the next one
+  });
+
+  it("narrows the query to the bridge contract when it is known", async () => {
+    const { promise, calls } = wait({
+      eth_blockNumber: ["0x2710"],
+      eth_getLogs: [[claimLog]],
+    }, { bridge: BRIDGE });
+    await promise;
+    const scan = calls.find((c) => c.method === "eth_getLogs")!.params as { address?: string };
+    expect(scan.address).toBe(BRIDGE);
+  });
+
+  // Matching on the hash rather than the recipient is what makes this exact:
+  // `Claim` indexes `to` too, but two same-amount withdrawals to one address
+  // would be indistinguishable under that filter.
+  it("filters on the claim hash as the second topic", async () => {
+    const { promise, calls } = wait({
+      eth_blockNumber: ["0x2710"],
+      eth_getLogs: [[claimLog]],
+    });
+    await promise;
+    const scan = calls.find((c) => c.method === "eth_getLogs")!.params as { topics: string[] };
+    expect(scan.topics).toEqual([CLAIM_TOPIC, CLAIM_HASH]);
+  });
+
+  /**
+   * A watch that aborts itself the first time `abortOn` is requested — either a
+   * JSON-RPC method name (stage 2) or a URL fragment (stage 1, which is a
+   * bodyless REST GET and so carries no method to match on).
+   */
+  const abortingAt = (abortOn: string, script: Record<string, unknown[]>, details?: unknown[]) => {
+    const controller = new AbortController();
+    const { fetchFn } = fakeAll(details ?? [detail("claimable")], script);
+    const wrapped = (async (url: string, init?: { body?: string }) => {
+      const method = init?.body
+        ? (JSON.parse(init.body) as { method: string }).method
+        : String(url);
+      if (method.includes(abortOn)) controller.abort();
+      return fetchFn(url, init);
+    }) as unknown as typeof fetch;
+    return waitForClaim({
+      restUrl: "http://pod/v1",
+      claimRpcUrl: "http://l1",
+      withdrawalId: ID,
+      pollMs: 5,
+      fetch: wrapped,
+      signal: controller.signal,
+    });
+  };
+
+  it("stops when aborted before the claim hash is known", async () => {
+    expect(await abortingAt("by-id", { eth_blockNumber: ["0x2710"] }, [detail("pending")]))
+      .toEqual({ state: "pending" });
+  });
+
+  // The hash is the expensive half to obtain (it waits on the certificate), so
+  // an abort after stage 1 hands it back — a caller resuming the watch doesn't
+  // have to re-derive it.
+  it("reports the claim hash when aborted while scanning for the event", async () => {
+    expect(await abortingAt("eth_getLogs", {
+      eth_blockNumber: ["0x2710"],
+      eth_getLogs: [[]], // never lands
+    })).toEqual({ state: "pending", claimHash: CLAIM_HASH });
+  });
+});
+
+describe("watchClaims", () => {
+  const ID2 = `0x${"44".repeat(32)}` as Hash;
+  const CLAIM_HASH2 = `0x${"55".repeat(32)}` as Hash;
+  const L1_TX2 = `0x${"66".repeat(32)}` as Hash;
+
+  const detailFor = (status: string, claimHash?: Hash) => ({
+    ok: true,
+    json: async () => ({
+      withdrawal: { withdrawal_id: ID, amount: "0x0", timestamp_us: 1 },
+      status,
+      ...(claimHash ? { proof: { claim_hash: claimHash } } : {}),
+    }),
+  });
+
+  const logFor = (claimHash: Hash, transactionHash: Hash) => ({
+    transactionHash,
+    topics: [CLAIM_TOPIC, claimHash],
+  });
+
+  /**
+   * Answers the REST by-id route FROM THE URL rather than from a queue, so a
+   * request for the wrong id cannot be satisfied by the next scripted reply.
+   * The queue-shaped double this replaces could not see the route it existed to
+   * exercise.
+   */
+  function fakeFor(details: Record<string, unknown>, script: Record<string, unknown[]>) {
+    const rpc = fakeRpc(script);
+    const fetchFn = (async (url: string, init?: { body?: string }) => {
+      if (init?.body) return (rpc.fetchFn as unknown as typeof fetch)(url, init as RequestInit);
+      const id = String(url).split("/").pop()!;
+      return (details[id] ?? { ok: false, status: 404, json: async () => ({}) }) as Response;
+    }) as unknown as typeof fetch;
+    return { fetchFn, calls: rpc.calls };
+  }
+
+  const settled = () => {
+    const seen: Array<[Hash, ClaimOutcome]> = [];
+    return { seen, onSettled: (id: Hash, o: ClaimOutcome) => void seen.push([id, o]) };
+  };
+
+  const tick = () => new Promise((r) => setTimeout(r, 10));
+
+  // The whole point of the batch watcher: two withdrawals, ONE log query.
+  it("covers every outstanding withdrawal with a single log query", async () => {
+    const { fetchFn, calls } = fakeFor(
+      { [ID]: detailFor("claimable", CLAIM_HASH), [ID2]: detailFor("claimable", CLAIM_HASH2) },
+      {
+        eth_blockNumber: ["0x2710"],
+        eth_getLogs: [[logFor(CLAIM_HASH, L1_TX), logFor(CLAIM_HASH2, L1_TX2)]],
+      },
+    );
+    const { seen, onSettled } = settled();
+    const w = watchClaims({
+      restUrl: "http://pod/v1", claimRpcUrl: "http://l1", pollMs: 0,
+      fetch: fetchFn as unknown as typeof fetch, onSettled,
+    });
+    w.add(ID);
+    w.add(ID2);
+    await tick();
+    w.stop();
+
+    expect(new Map(seen)).toEqual(new Map([
+      [ID, { state: "claimed", claimHash: CLAIM_HASH, transactionHash: L1_TX }],
+      [ID2, { state: "claimed", claimHash: CLAIM_HASH2, transactionHash: L1_TX2 }],
+    ]));
+    // Both hashes rode one query, and each claim went to its own withdrawal.
+    const scans = calls.filter((c) => c.method === "eth_getLogs");
+    expect(scans).toHaveLength(1);
+    expect((scans[0]!.params as { topics: unknown[] }).topics[1]).toEqual([CLAIM_HASH, CLAIM_HASH2]);
+    expect(w.size).toBe(0);
+  });
+
+  // Terminal on pod, so it never reaches the claim chain at all.
+  it("settles a refused withdrawal without scanning for it", async () => {
+    const { fetchFn, calls } = fakeFor({ [ID]: detailFor("refused") }, { eth_blockNumber: ["0x2710"] });
+    const { seen, onSettled } = settled();
+    const w = watchClaims({
+      restUrl: "http://pod/v1", claimRpcUrl: "http://l1", pollMs: 0,
+      fetch: fetchFn as unknown as typeof fetch, onSettled,
+    });
+    w.add(ID);
+    await tick();
+    w.stop();
+
+    expect(seen).toEqual([[ID, { state: "refused" }]]);
+    expect(calls.some((c) => c.method === "eth_getLogs")).toBe(false);
+  });
+
+  // The floor is per id, and this is why. W2 sits in stage 1 for several polls
+  // while W1 is already claimable, so every scan carries only W1's hash — and a
+  // scan that could not have matched W2 must not be allowed to step over the
+  // blocks W2 still needs searched. A relayer can claim from a certificate this
+  // node has not finished assembling, so those blocks are exactly where W2's
+  // Claim lands. Advancing on W1's behalf loses it permanently and silently.
+  it("does not advance past blocks a still-unresolved withdrawal needs searched", async () => {
+    const details: Record<string, unknown> = {
+      [ID]: detailFor("claimable", CLAIM_HASH),
+      [ID2]: detailFor("pending"), // W2 has no certificate yet
+    };
+    const { fetchFn, calls } = fakeFor(details, {
+      eth_blockNumber: ["0x2710", "0x2720", "0x2730"],
+      eth_getLogs: [[]],
+    });
+    const { seen, onSettled } = settled();
+    const w = watchClaims({
+      restUrl: "http://pod/v1", claimRpcUrl: "http://l1", pollMs: 0,
+      fetch: fetchFn as unknown as typeof fetch, onSettled,
+    });
+    w.add(ID);
+    w.add(ID2);
+    await tick();
+    // W2's certificate lands, and its claim was emitted back in the window that
+    // passed while it was pending.
+    details[ID2] = detailFor("claimable", CLAIM_HASH2);
+    await tick();
+    w.stop();
+
+    const scans = calls.filter((c) => c.method === "eth_getLogs")
+      .map((c) => c.params as { fromBlock: string; topics: unknown[] });
+    const withW2 = scans.find((s) => (s.topics[1] as string[]).includes(CLAIM_HASH2));
+    expect(withW2, "a scan should eventually carry W2's hash").toBeDefined();
+    // The scan that finally looks for W2 must still start at W2's own floor,
+    // not at wherever W1's scans had marched the window to.
+    expect(BigInt(withW2!.fromBlock)).toBeLessThanOrEqual(0x2710n);
+    expect(seen).toEqual([]); // neither has been claimed in this scenario
+  });
+
+  // Each id's floor is pinned when it joins, so a later arrival reaches back to
+  // its own lookback rather than inheriting wherever the window had reached.
+  it("starts the shared query at the oldest floor among outstanding ids", async () => {
+    const { fetchFn, calls } = fakeFor(
+      { [ID]: detailFor("claimable", CLAIM_HASH), [ID2]: detailFor("claimable", CLAIM_HASH2) },
+      { eth_blockNumber: ["0x2710"], eth_getLogs: [[]] },
+    );
+    const { onSettled } = settled();
+    const w = watchClaims({
+      restUrl: "http://pod/v1", claimRpcUrl: "http://l1", pollMs: 0,
+      fetch: fetchFn as unknown as typeof fetch, onSettled,
+    });
+    w.add(ID); // no lookback: starts at the tip
+    await tick();
+    w.add(ID2, { lookbackBlocks: 500 });
+    await tick();
+    w.stop();
+
+    const froms = calls.filter((c) => c.method === "eth_getLogs")
+      .map((c) => BigInt((c.params as { fromBlock: string }).fromBlock));
+    expect(froms[0]).toBe(0x2710n); // first scan anchored at the tip
+    // Some later scan reaches back below it, rather than only marching forward.
+    expect(froms.some((f) => f <= 0x2710n - 500n)).toBe(true);
+  });
+});

--- a/ts-sdk/src/transport/claim.ts
+++ b/ts-sdk/src/transport/claim.ts
@@ -43,14 +43,23 @@ export type ClaimStatus =
 /**
  * Resolve one withdrawal's claim state from the pod node.
  *
- * The node reports it directly — `status` is always present and is the authority,
- * so nothing here infers terminality from a missing field or an error string. The
- * three states are not interchangeable: `pending` means fewer than N−F signatures
- * are held *on this node* and the caller should ask again, while `refused` means
- * the withdrawal was rejected at execution with nothing debited.
+ * **The precedence is deliberate and is the forward-compatibility contract — do
+ * not "simplify" it into a switch on `status`:**
  *
- * A 404 is neither — it means this node has no outcome row yet, which is the
- * normal state for the first moments after submitting, so it reads as `pending`.
+ * 1. A present `proof.claim_hash` wins, whatever `status` says. The money is in
+ *    the certificate, not in the word beside it, and a status this build has
+ *    never heard of must not veto one sitting in the same response.
+ * 2. Only then may `status` be terminal, and only `refused` is — meaning the
+ *    withdrawal was rejected at execution with nothing debited.
+ * 3. Everything else is `pending`, i.e. "ask again": an unfamiliar status, a
+ *    404 (this node has no outcome row yet, normal right after submitting), any
+ *    other HTTP failure, and a transport error. None of them is information
+ *    about the withdrawal, and guessing `refused` would tell a user their funds
+ *    were never taken when they may well have been.
+ *
+ * This mirrors the two properties the node's own `WithdrawalDetail` documents
+ * for consumers (node/src/rpc/bridge_rest.rs), which its producer type
+ * deliberately does not provide.
  */
 export async function fetchClaimStatus(
   restUrl: string,
@@ -59,7 +68,13 @@ export async function fetchClaimStatus(
 ): Promise<ClaimStatus> {
   const doFetch = opts?.fetch ?? fetch;
   try {
-    const res = await doFetch(`${restUrl}/bridge/withdrawals/by-id/${withdrawalId}`, {
+    // Trailing slashes are stripped because `PodRestClient` accepts a base with
+    // one and this helper is handed the same value. `https://host/v1/` would
+    // otherwise request `/v1//bridge/...`, and a 404 from that is indistinguishable
+    // here from a certificate that has not assembled yet — so the watch would
+    // poll a misspelled URL forever without surfacing anything.
+    const base = restUrl.replace(/\/+$/, "");
+    const res = await doFetch(`${base}/bridge/withdrawals/by-id/${withdrawalId}`, {
       headers: { accept: "application/json" },
       signal: opts?.signal,
     });
@@ -276,8 +291,24 @@ export function watchClaims(opts: WatchClaimsOptions): ClaimWatcher {
   const pending = new Map<Hash, Entry>();
   let stopped = false;
   let wake: (() => void) | undefined;
+  /**
+   * The newest head this watcher has seen. Kept so `add` can anchor immediately
+   * rather than waiting for the next tick to do it: an id added while a scan is
+   * in flight is not covered by `wake` (the watcher is not sleeping) and would
+   * otherwise be anchored at the FOLLOWING head, silently skipping every block
+   * between the call and that read — the exact window a per-id floor exists to
+   * preserve. Undefined only before the first head read, where nothing has been
+   * scanned yet and the first tick anchors it correctly.
+   */
+  let lastHead: bigint | undefined;
 
   const live = () => !stopped && !signal?.aborted;
+
+  /** The oldest block an id joining at `head` still needs searched. */
+  const anchorFrom = (head: bigint, lookback: number) => {
+    const back = BigInt(lookback);
+    return head > back ? head - back : 0n;
+  };
 
   const sleep = () => new Promise<void>((resolve) => {
     const timer = setTimeout(done, pollMs);
@@ -322,11 +353,9 @@ export function watchClaims(opts: WatchClaimsOptions): ClaimWatcher {
     const head = await tryRpc<string>(claimRpcUrl, "eth_blockNumber", [], rest);
     if (head === undefined) return;
     const toBlock = BigInt(head);
+    lastHead = toBlock;
     for (const entry of pending.values()) {
-      if (entry.floor === undefined) {
-        const back = BigInt(entry.lookback);
-        entry.floor = toBlock > back ? toBlock - back : 0n;
-      }
+      if (entry.floor === undefined) entry.floor = anchorFrom(toBlock, entry.lookback);
     }
 
     const hashes = [...pending.values()].map((e) => e.claimHash).filter((h): h is Hash => !!h);
@@ -383,8 +412,16 @@ export function watchClaims(opts: WatchClaimsOptions): ClaimWatcher {
   return {
     add(withdrawalId, addOpts) {
       if (stopped || pending.has(withdrawalId)) return;
-      pending.set(withdrawalId, { lookback: addOpts?.lookbackBlocks ?? 0 });
-      wake?.(); // pin its floor now rather than after the current sleep
+      const lookback = addOpts?.lookbackBlocks ?? 0;
+      // Anchor from the last head seen, NOT from whatever the next tick reads.
+      // `wake` only helps while the watcher is sleeping; an id added during an
+      // in-flight scan would otherwise be pinned at a later head and lose every
+      // block in between.
+      pending.set(withdrawalId, {
+        lookback,
+        floor: lastHead === undefined ? undefined : anchorFrom(lastHead, lookback),
+      });
+      wake?.(); // and start looking now rather than after the current sleep
     },
     get size() {
       return pending.size;

--- a/ts-sdk/src/transport/claim.ts
+++ b/ts-sdk/src/transport/claim.ts
@@ -1,0 +1,397 @@
+// Following a withdrawal from pod onto the claim chain (ADR 0033).
+//
+// Two stages, because the claim hash is not known when the withdrawal resolves:
+// ask the pod node for it, then watch the claim chain for the bridge's `Claim`
+// event carrying it. Both live here rather than in a consumer because the event
+// ABI, the topic filter and the log-range policy are protocol knowledge that
+// has to track the bridge contract, not application code.
+//
+// Stage 1 is REST (`GET /v1/bridge/withdrawals/by-id/{id}`), stage 2 is JSON-RPC
+// against the claim chain — the asymmetry is just where each fact lives.
+//
+// **The claim hash is fetched, never recomputed.** It folds in the pod chain id
+// and the bridge version, so a local derivation is a second copy of a
+// consensus-critical hash that silently stops matching after a version bump —
+// the node serves it so that callers don't (ADR 0033 §4.6). Everything else in
+// this module is a consequence of that: it is why stage 1 exists at all.
+
+import type { Address, Hash } from "../types/public.js";
+import { tryRpc, type RpcOptions } from "./jsonrpc.js";
+import type { WireWithdrawalDetail } from "../types/wire.js";
+
+/**
+ * topic0 of `Claim(bytes32 indexed txHash, address token, address mirrorToken,
+ * uint256 amount, address indexed to)` — protocol/src/Bridge.sol.
+ *
+ * A literal rather than a derivation so the read path doesn't pull in an ABI
+ * encoder; `claim.test.ts` pins it against viem's `toEventSelector`, so it
+ * cannot drift from the signature above without failing a test.
+ */
+export const CLAIM_TOPIC: Hash =
+  "0xa0b99c0fdfc395724d7b81a88a6d74852461f7691371afe2839bb8688475788c";
+
+/** Where a withdrawal has got to on its way to the claim chain. */
+export type ClaimStatus =
+  /** The certificate is still assembling (below the signature threshold). */
+  | { state: "pending" }
+  /** Claimable. `claimHash` is the `Claim` event's indexed `txHash`. */
+  | { state: "claimable"; claimHash: Hash }
+  /** Refused at execution: nothing was debited, so no `Claim` event can ever
+   * fire and the user can resubmit under a new id. Terminal. */
+  | { state: "refused" };
+
+/**
+ * Resolve one withdrawal's claim state from the pod node.
+ *
+ * The node reports it directly — `status` is always present and is the authority,
+ * so nothing here infers terminality from a missing field or an error string. The
+ * three states are not interchangeable: `pending` means fewer than N−F signatures
+ * are held *on this node* and the caller should ask again, while `refused` means
+ * the withdrawal was rejected at execution with nothing debited.
+ *
+ * A 404 is neither — it means this node has no outcome row yet, which is the
+ * normal state for the first moments after submitting, so it reads as `pending`.
+ */
+export async function fetchClaimStatus(
+  restUrl: string,
+  withdrawalId: Hash,
+  opts?: RpcOptions,
+): Promise<ClaimStatus> {
+  const doFetch = opts?.fetch ?? fetch;
+  try {
+    const res = await doFetch(`${restUrl}/bridge/withdrawals/by-id/${withdrawalId}`, {
+      headers: { accept: "application/json" },
+      signal: opts?.signal,
+    });
+    // Anything non-OK, 404 included, is "ask again": the row may not be written
+    // yet, and no HTTP status carries terminality — only `status` does.
+    if (!res.ok) return { state: "pending" };
+    const body = (await res.json()) as WireWithdrawalDetail;
+    // The proof is read FIRST and believed on its presence alone, whatever
+    // `status` says. That ordering is the node's own consumer contract
+    // (`WithdrawalDetail`, node/src/rpc/bridge_rest.rs): a node that adds a
+    // fourth status while still attaching a certificate must not have that
+    // certificate vetoed by a label this client has never heard of. The money
+    // is in the proof, not in the word next to it.
+    const claimHash = body.proof?.claim_hash;
+    if (claimHash) return { state: "claimable", claimHash };
+    // Only now may a status be terminal, and only this one. Anything unfamiliar
+    // falls through to `pending` — "ask again", never terminal.
+    if (body.status === "refused") return { state: "refused" };
+    return { state: "pending" };
+  } catch {
+    // A transport failure is not information about the withdrawal. Guessing
+    // `refused` here would tell a user their funds were never taken when they may
+    // well have been.
+    return { state: "pending" };
+  }
+}
+
+export interface WaitForClaimOptions extends RpcOptions {
+  /** pod REST base, as `PodTradeClient` takes it — `""` for a same-origin
+   * browser deployment. Stage 1 lives entirely on this surface; no JSON-RPC. */
+  restUrl: string;
+  /** Claim-chain JSON-RPC — where the `Claim` event is emitted. */
+  claimRpcUrl: string;
+  withdrawalId: Hash;
+  /** The bridge on the claim chain (`BridgeConfig.sourceContract`). Narrows the
+   * log query to one contract; omit only if it isn't known. */
+  bridge?: Address;
+  /** Give up after this long. Default 10 minutes. */
+  timeoutMs?: number;
+  /** Default 5s. */
+  pollMs?: number;
+  /** How far before the current block the log scan starts, covering a relayer
+   * that claimed before the watch began. Default 5000.
+   *
+   * Worth lowering for a watch started as the withdrawal resolves: the claim
+   * cannot predate the outcome, so the window is known-empty, and this is both
+   * the largest query of the watch and the one public providers cap by range. */
+  lookbackBlocks?: number;
+}
+
+export type ClaimOutcome =
+  /** The funds landed. */
+  | { state: "claimed"; claimHash: Hash; transactionHash: Hash }
+  /** Refused at execution; nothing was debited and nothing will arrive. */
+  | { state: "refused" }
+  /** Still outstanding when the timeout or the abort signal hit. Carries the
+   * claim hash if stage 1 got that far, so a caller can resume the watch. */
+  | { state: "pending"; claimHash?: Hash };
+
+/**
+ * Follow one withdrawal to the claim chain: resolve its claim hash, then watch
+ * for the `Claim` event carrying it.
+ *
+ * Matching on the hash rather than the recipient is what makes this exact —
+ * `Claim` indexes `to` as well, but that identifies the *user*, so two
+ * withdrawals of the same amount to the same address would be indistinguishable.
+ *
+ * Returns rather than throws on every expected ending, so a caller renders an
+ * outcome instead of catching. Pass `signal` to stop the polling when whatever
+ * asked for it goes away.
+ */
+export async function waitForClaim(opts: WaitForClaimOptions): Promise<ClaimOutcome> {
+  const { restUrl, claimRpcUrl, withdrawalId, bridge, signal } = opts;
+  const pollMs = opts.pollMs ?? 5_000;
+  const lookback = opts.lookbackBlocks ?? 5_000;
+  const deadline = Date.now() + (opts.timeoutMs ?? 10 * 60_000);
+  const rest = { fetch: opts.fetch, signal };
+
+  const live = () => !signal?.aborted && Date.now() < deadline;
+  const sleep = () => new Promise<void>((resolve) => {
+    const timer = setTimeout(done, pollMs);
+    function done() { signal?.removeEventListener("abort", done); clearTimeout(timer); resolve(); }
+    signal?.addEventListener("abort", done, { once: true });
+  });
+
+  // Anchor the scan window before stage 1, so the range stays bounded however
+  // long the certificate takes to assemble. This same reading is the first
+  // scan's upper bound, so stage 2 costs no extra round trip to start.
+  const tip = await tryRpc<string>(claimRpcUrl, "eth_blockNumber", [], rest);
+  if (tip === undefined) return { state: "pending" };
+  let head: bigint | undefined = BigInt(tip);
+  let fromBlock = head > BigInt(lookback) ? head - BigInt(lookback) : 0n;
+
+  let claimHash: Hash | undefined;
+  while (!claimHash && live()) {
+    const status = await fetchClaimStatus(restUrl, withdrawalId, rest);
+    if (status.state === "refused") return { state: "refused" };
+    if (status.state === "claimable") claimHash = status.claimHash;
+    else await sleep();
+  }
+  if (!claimHash) return { state: "pending" };
+
+  while (live()) {
+    // The upper bound is pinned BEFORE the scan and named explicitly. With
+    // `toBlock: "latest"` the node picks the end itself, and any block mined
+    // between that choice and a later head read would be stepped over by the
+    // advance below — permanently, since the window only moves forward. On a
+    // 250ms-block chain that silently loses the claim a few percent of the time.
+    if (head === undefined) {
+      const latest = await tryRpc<string>(claimRpcUrl, "eth_blockNumber", [], rest);
+      if (latest === undefined) { await sleep(); continue; }
+      head = BigInt(latest);
+    }
+    const toBlock = head;
+    head = undefined; // re-read on the next pass; this one is now spent
+
+    if (toBlock >= fromBlock) {
+      const filter: Record<string, unknown> = {
+        fromBlock: `0x${fromBlock.toString(16)}`,
+        toBlock: `0x${toBlock.toString(16)}`,
+        topics: [CLAIM_TOPIC, claimHash],
+      };
+      if (bridge) filter.address = bridge;
+      const logs = await tryRpc<Array<{ transactionHash: Hash }>>(
+        claimRpcUrl, "eth_getLogs", [filter], rest,
+      );
+      const hit = logs?.[0];
+      if (hit) return { state: "claimed", claimHash, transactionHash: hit.transactionHash };
+
+      // Only advance on a scan that actually completed. `tryRpc` maps a 429, a
+      // 5xx or "query returned more than 10000 results" to undefined, which is
+      // indistinguishable from an empty result — advancing there would skip the
+      // range unread, and the lookback window is the one covering a relayer that
+      // claimed before this watch began.
+      if (logs !== undefined) fromBlock = toBlock + 1n;
+    }
+    await sleep();
+  }
+  return { state: "pending", claimHash };
+}
+
+export interface WatchClaimsOptions extends RpcOptions {
+  /** pod REST base, as `PodTradeClient` takes it. */
+  restUrl: string;
+  /** Claim-chain JSON-RPC — where the `Claim` event is emitted. */
+  claimRpcUrl: string;
+  /** The bridge on the claim chain (`BridgeConfig.sourceContract`). */
+  bridge?: Address;
+  /** Default 5s. */
+  pollMs?: number;
+  /** Called once per withdrawal, when it reaches a terminal state. Never called
+   * for one still outstanding when the watcher stops. */
+  onSettled: (withdrawalId: Hash, outcome: ClaimOutcome) => void;
+}
+
+export interface ClaimWatcher {
+  /**
+   * Follow one withdrawal. Ignored if it is already followed, so a caller may
+   * re-offer the same id freely. It is NOT ignored for an id that has already
+   * settled, because the watcher forgets those — deduplicating across
+   * settlement belongs to the caller, which is the only side that knows whether
+   * it acted on the outcome.
+   *
+   * `lookbackBlocks` covers a claim emitted before this id joined. It sets this
+   * id's OWN scan floor, and the shared query starts at the oldest floor among
+   * outstanding ids — so a range already scanned for others is re-scanned for
+   * this one, and no id's window is ever skipped on another's behalf.
+   */
+  add(withdrawalId: Hash, opts?: { lookbackBlocks?: number }): void;
+  /** How many withdrawals are still outstanding. */
+  readonly size: number;
+  stop(): void;
+}
+
+/**
+ * Follow many withdrawals on one pair of loops instead of one pair each.
+ *
+ * The saving is on the claim chain, which is the half that costs: a `Claim`
+ * topic filter is an OR set at `topics[1]`, so a single `eth_getLogs` covers
+ * every outstanding hash and that query's count stops scaling with the number of
+ * withdrawals. Stage 1 still costs one REST read per unresolved id, issued
+ * concurrently rather than in series — those go to pod's own node, not to a
+ * metered provider, so the thing worth collapsing is the log scan.
+ *
+ * **Each id carries its own scan floor, and the shared query starts at the
+ * oldest of them.** This is the part that is easy to get wrong: a withdrawal
+ * still waiting for its certificate has no hash to search for yet, so it
+ * contributes nothing to the topic set — but the blocks passing meanwhile are
+ * exactly where its `Claim` may land, because a relayer can claim from a
+ * certificate this node has not finished assembling. Advancing the floor on the
+ * strength of the ids that *do* have hashes would step over that window for
+ * good. So a floor is only raised for an id whose hash was actually in the query
+ * that covered it.
+ *
+ * Settlement arrives through `onSettled` rather than a promise per id, so a
+ * caller hears about each outcome when it happens rather than when the slowest
+ * one does.
+ */
+export function watchClaims(opts: WatchClaimsOptions): ClaimWatcher {
+  const { restUrl, claimRpcUrl, bridge, signal, onSettled } = opts;
+  const pollMs = opts.pollMs ?? 5_000;
+  const rest = { fetch: opts.fetch, signal };
+
+  interface Entry {
+    /** Set once the certificate exists. Lower-cased: it is compared against a
+     * topic from a different source, and hex casing is not guaranteed to agree. */
+    claimHash?: Hash;
+    /** Oldest block this id still needs searched. Pinned on the first tick after
+     * `add`, then raised only by a query that actually carried its hash. */
+    floor?: bigint;
+    lookback: number;
+  }
+
+  const pending = new Map<Hash, Entry>();
+  let stopped = false;
+  let wake: (() => void) | undefined;
+
+  const live = () => !stopped && !signal?.aborted;
+
+  const sleep = () => new Promise<void>((resolve) => {
+    const timer = setTimeout(done, pollMs);
+    wake = done;
+    function done() {
+      signal?.removeEventListener("abort", done);
+      clearTimeout(timer);
+      wake = undefined;
+      resolve();
+    }
+    signal?.addEventListener("abort", done, { once: true });
+  });
+
+  /** Terminal for one id. Silent once stopped: `stop()` cannot cancel an
+   * in-flight request, and a caller that has torn down its state must not be
+   * told about an outcome afterwards — it would announce a claim for an account
+   * the user has left, and un-mark an id its own cleanup had just released. */
+  const settle = (id: Hash, outcome: ClaimOutcome) => {
+    if (!live()) return;
+    pending.delete(id);
+    onSettled(id, outcome);
+  };
+
+  async function tick(): Promise<void> {
+    // Stage 1, concurrently: the reads share no state until their results are
+    // written back, so in series they would simply add up one RTT at a time.
+    const unresolved = [...pending].filter(([, e]) => !e.claimHash);
+    const statuses = await Promise.all(
+      unresolved.map(([id]) => fetchClaimStatus(restUrl, id, rest)),
+    );
+    unresolved.forEach(([id, entry], i) => {
+      const status = statuses[i]!;
+      if (status.state === "refused") settle(id, { state: "refused" });
+      else if (status.state === "claimable") entry.claimHash = status.claimHash.toLowerCase() as Hash;
+    });
+    if (!live() || pending.size === 0) return;
+
+    // The tip is read every tick, even with nothing to search for yet, because
+    // it is what pins a newcomer's floor. Deferring that until a hash exists
+    // would anchor it at a later block than the one it joined at, losing the
+    // window in between — the same mistake as advancing past an unresolved id.
+    const head = await tryRpc<string>(claimRpcUrl, "eth_blockNumber", [], rest);
+    if (head === undefined) return;
+    const toBlock = BigInt(head);
+    for (const entry of pending.values()) {
+      if (entry.floor === undefined) {
+        const back = BigInt(entry.lookback);
+        entry.floor = toBlock > back ? toBlock - back : 0n;
+      }
+    }
+
+    const hashes = [...pending.values()].map((e) => e.claimHash).filter((h): h is Hash => !!h);
+    if (hashes.length === 0) return; // nothing to look for; floors are pinned
+
+    let fromBlock = toBlock;
+    for (const entry of pending.values()) {
+      if (entry.floor !== undefined && entry.floor < fromBlock) fromBlock = entry.floor;
+    }
+    if (toBlock < fromBlock) return;
+
+    const filter: Record<string, unknown> = {
+      fromBlock: `0x${fromBlock.toString(16)}`,
+      toBlock: `0x${toBlock.toString(16)}`,
+      // An array at `topics[1]` is an OR over claim hashes — the whole reason
+      // one query can serve every outstanding withdrawal.
+      topics: [CLAIM_TOPIC, hashes],
+    };
+    if (bridge) filter.address = bridge;
+
+    const logs = await tryRpc<Array<{ transactionHash: Hash; topics: Hash[] }>>(
+      claimRpcUrl, "eth_getLogs", [filter], rest,
+    );
+    // Undefined is a failed query, not an empty range, so no floor may move.
+    if (logs === undefined) return;
+
+    for (const log of logs) {
+      const claimHash = log.topics[1]?.toLowerCase() as Hash | undefined;
+      if (!claimHash) continue;
+      for (const [id, entry] of [...pending]) {
+        if (entry.claimHash === claimHash) {
+          settle(id, { state: "claimed", claimHash, transactionHash: log.transactionHash });
+        }
+      }
+    }
+    // Raise the floor ONLY for ids whose hash this query carried. One that is
+    // still waiting on its certificate keeps its original floor, so the blocks
+    // that passed while it waited are searched once its hash appears.
+    const searched = new Set(hashes);
+    for (const entry of pending.values()) {
+      if (entry.claimHash && searched.has(entry.claimHash)) entry.floor = toBlock + 1n;
+    }
+  }
+
+  async function run(): Promise<void> {
+    while (live()) {
+      if (pending.size > 0) await tick();
+      await sleep();
+    }
+  }
+
+  void run();
+
+  return {
+    add(withdrawalId, addOpts) {
+      if (stopped || pending.has(withdrawalId)) return;
+      pending.set(withdrawalId, { lookback: addOpts?.lookbackBlocks ?? 0 });
+      wake?.(); // pin its floor now rather than after the current sleep
+    },
+    get size() {
+      return pending.size;
+    },
+    stop() {
+      stopped = true;
+      wake?.();
+    },
+  };
+}

--- a/ts-sdk/src/transport/jsonrpc.ts
+++ b/ts-sdk/src/transport/jsonrpc.ts
@@ -1,0 +1,54 @@
+// One JSON-RPC POST, shared by every raw-RPC caller in the SDK.
+//
+// Deliberately not viem: this is reachable from the main entry, and read-only
+// consumers should not pull a signing library in to read a block number. The
+// `/write` entry uses viem because it must.
+
+export interface RpcOptions {
+  fetch?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+export class PodRpcError extends Error {
+  constructor(public code: number | undefined, message: string) {
+    super(message);
+    this.name = "PodRpcError";
+  }
+}
+
+/** Call `method` and return its result, throwing {@link PodRpcError} on an
+ * error response. Use {@link tryRpc} where an error is an expected state. */
+export async function rpc<T>(
+  rpcUrl: string,
+  method: string,
+  params: unknown[] = [],
+  opts?: RpcOptions,
+): Promise<T> {
+  const doFetch = opts?.fetch ?? fetch;
+  const res = await doFetch(rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    signal: opts?.signal,
+  });
+  const json = (await res.json()) as { result?: T; error?: { code?: number; message?: string } };
+  if (json.error) throw new PodRpcError(json.error.code, json.error.message ?? `${method} failed`);
+  if (json.result === undefined) throw new PodRpcError(undefined, `${method} returned no result`);
+  return json.result;
+}
+
+/** {@link rpc}, but an error response (or a transport failure) yields
+ * `undefined` instead of throwing — for methods whose failure is a state the
+ * caller expects and handles, not an exception. */
+export async function tryRpc<T>(
+  rpcUrl: string,
+  method: string,
+  params: unknown[] = [],
+  opts?: RpcOptions,
+): Promise<T | undefined> {
+  try {
+    return await rpc<T>(rpcUrl, method, params, opts);
+  } catch {
+    return undefined;
+  }
+}

--- a/ts-sdk/src/transport/rest.ts
+++ b/ts-sdk/src/transport/rest.ts
@@ -3,17 +3,19 @@
 // ms in, decoded (bigint / ms) out.
 
 import type {
-  Address, BackstopTransfer, Balances, Bar, CandleQuery, LeaderboardPage, LeaderboardQuery,
-  Market, MarketId, Order, Orderbook, PositionsSnapshot, Resolution, Status, Trigger, TxExplorer,
+  Address, BackstopTransfer, Balances, Bar, BridgeConfig, CandleQuery, LeaderboardPage,
+  LeaderboardQuery, Market, MarketId, Order, Orderbook, PositionsSnapshot, Resolution, Status,
+  Trigger, TxExplorer, Withdrawal, WithdrawalsQuery,
 } from "../types/public.js";
 import type {
-  WireBackstopPage, WireBalances, WireCandlesEnvelope, WireLeaderboard, WireMarketStatic,
-  WireMarketStatsPage, WireOrderbook, WireOrdersPage, WirePositionsSnapshot, WireStatus,
-  WireTriggersPage,
+  WireBackstopPage, WireBalances, WireBridgeConfig, WireCandlesEnvelope, WireLeaderboard,
+  WireMarketStatic, WireMarketStatsPage, WireOrderbook, WireOrdersPage, WirePositionsSnapshot,
+  WireStatus, WireTriggersPage, WireWithdrawal,
 } from "../types/wire.js";
 import {
-  decodeBackstopTransfer, decodeBalances, decodeCandle, decodeLeaderboard, decodeMarketDynamics,
-  decodeMarketStatic, decodeOrder, decodeOrderbook, decodePositions, decodeStatus, decodeTrigger,
+  decodeBackstopTransfer, decodeBalances, decodeBridgeConfig, decodeCandle, decodeLeaderboard,
+  decodeMarketDynamics, decodeMarketStatic, decodeOrder, decodeOrderbook, decodePositions,
+  decodeStatus, decodeTrigger, decodeWithdrawal,
 } from "../codec/decode.js";
 import { msToSecs, usToMs } from "../codec/units.js";
 
@@ -197,6 +199,32 @@ export class PodRestClient {
       limit: q?.limit, offset: q?.offset, address: q?.account,
     });
     return decodeLeaderboard(w, q?.offset ?? 0);
+  }
+
+  /** Static bridge config: the claim chain, the bridge contract, and every
+   * bridged token's L1 address, decimals and withdraw window (ADR 0033 §5).
+   * Served unconditionally — it is not behind the CLOB indexer's gate. */
+  async bridgeConfig(): Promise<BridgeConfig> {
+    return decodeBridgeConfig(await this.get<WireBridgeConfig>("/bridge/config"));
+  }
+
+  /**
+   * Terminal withdrawal outcomes, newest cursor last. Omit `account` for every
+   * account (what a relayer wants); pass one to scope it to a single user.
+   *
+   * This is the reconnect backfill behind the `pod_withdrawals` subscription:
+   * the rows decode to exactly the same shape the stream pushes, so a client
+   * cannot tell which one an outcome arrived on. Page with `since` (the tick
+   * cursor) plus `sinceId` to resume *inside* a tick that spanned a page.
+   */
+  async bridgeWithdrawals(account?: Address, q?: WithdrawalsQuery): Promise<Withdrawal[]> {
+    const path = account ? `/bridge/withdrawals/${account}` : "/bridge/withdrawals";
+    const w = await this.get<WireWithdrawal[]>(path, {
+      since: q?.since,
+      since_id: q?.sinceId,
+      limit: q?.limit,
+    });
+    return w.map(decodeWithdrawal);
   }
 
   async triggers(account: Address, q?: TriggersQueryRest): Promise<TriggersPage> {

--- a/ts-sdk/src/transport/ws.ts
+++ b/ts-sdk/src/transport/ws.ts
@@ -7,7 +7,10 @@ import type { Address, MarketId } from "../types/public.js";
 
 export type Channel =
   | "pod_orderbook" | "pod_orders_v2" | "pod_candles"
-  | "pod_markets" | "pod_positions" | "pod_triggers";
+  | "pod_markets" | "pod_positions" | "pod_triggers"
+  /** Terminal withdrawal outcomes; one array per tick, `account`-filtered on the
+   * debited account (the master, under delegation). ADR 0033 §6. */
+  | "pod_withdrawals";
 
 export interface SubParams {
   clobIds?: MarketId[];

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -465,3 +465,97 @@ export interface TriggersQuery {
   orderbookId?: MarketId;
   limit?: number;
 }
+
+// --- bridge / withdrawals (ADR 0033) ---
+
+/**
+ * One bridged token, as `GET /v1/bridge/config` serves it.
+ *
+ * `min`, `max` and `decimals` are all on the **claim chain's** terms, not pod's
+ * 18 — see `codec/bridge.ts`, which owns that conversion.
+ */
+export interface BridgeToken {
+  podToken: Address;
+  l1Token: Address;
+  /** Decimals on the claim chain, and so the withdrawal granularity on pod. */
+  decimals: number;
+  /** Smallest admissible withdrawal, in claim-chain decimals. */
+  min: bigint;
+  /** Largest admissible withdrawal, in claim-chain decimals. */
+  max: bigint;
+}
+
+/** Static bridge configuration — the one chain pod withdrawals settle on. */
+export interface BridgeConfig {
+  /** `0` when the node has no bridge configured, in which case `tokens` is
+   * empty and no withdrawal is admissible at all. */
+  claimChainId: number;
+  /** The bridge contract on the claim chain, where `Claim` is emitted. */
+  sourceContract: Address;
+  /** Bridge version; feeds the claim-hash domain separator. */
+  version: number;
+  tokens: BridgeToken[];
+}
+
+/**
+ * Why a withdrawal produced no L1 claim. Any value here means **no L1 event will
+ * ever fire**, so a client watching only the claim chain would wait forever —
+ * this is the only place a reason exists.
+ */
+export type WithdrawalError =
+  /** The CLOB balance did not cover it at execution. Admission deliberately
+   * doesn't check the balance (pending fills can raise it), so this races that. */
+  | "insufficient_balance"
+  /** The solver never included the intent before its deadline. Funds are
+   * untouched and the withdrawal can simply be resubmitted. */
+  | "not_included"
+  /**
+   * Any other reason a node reports. This set is **open by construction**: the
+   * node's reason enum is explicitly extensible and an app ships ahead of the
+   * fleet, so a spelling this build predates has to arrive verbatim rather than
+   * be dropped. Dropping it makes a *failed* withdrawal read as claimable —
+   * the one direction it is unsafe to be lossy in, because the caller then
+   * reports success and waits for a claim that can never land.
+   *
+   * `(string & {})` keeps the two known values in editor completion while still
+   * admitting the rest. Treat an unknown reason exactly like a known one, and
+   * show it verbatim rather than guessing which known reason it resembles.
+   */
+  | (string & {});
+
+/** One terminal withdrawal outcome, from `pod_withdrawals` or its REST backfill. */
+export interface Withdrawal {
+  /** `keccak(abi.encode(signer, nonce, sequence))` — derivable client-side
+   * before submitting, which is what lets a client match its own withdrawal. */
+  id: Hash;
+  /** The debited account: the master, for a delegated withdrawal. */
+  withdrawer: Address;
+  /** Recipient on the **claim chain**. Nothing is credited on pod. */
+  to: Address;
+  /** Pod-side token address. */
+  token: Address;
+  /** Pod's 18 decimals, as signed. The L1 claim carries this converted to the
+   * token's claim-chain decimals — never pass this value to `claim`. */
+  amount: bigint;
+  /** Absent when the withdrawal is claimable on L1. */
+  error?: WithdrawalError;
+  /**
+   * The tick's batch deadline, in **microseconds** — not the millisecond
+   * convention the rest of this surface uses.
+   *
+   * Deliberate: this value is also the resume cursor for `pod_withdrawals` and
+   * for the REST backfill, both of which compare it in micros. Narrowing it to
+   * ms and back would round a tick boundary and silently re-serve or skip a
+   * tick, so it stays in the unit the server compares.
+   */
+  timeUs: number;
+}
+
+export interface WithdrawalsQuery {
+  /** Batch deadline in microseconds; strictly greater. */
+  since?: number;
+  /** Last id already seen *within* the `since` tick, to resume mid-tick. */
+  sinceId?: Hash;
+  /** Server default 500, capped at 1000. */
+  limit?: number;
+}

--- a/ts-sdk/src/types/wire.ts
+++ b/ts-sdk/src/types/wire.ts
@@ -384,3 +384,47 @@ export interface WireTriggersPush {
   total_count: number;
   next_cursor: string | null;
 }
+
+// --- bridge / withdrawals (ADR 0033) ---
+
+export interface WireBridgeToken {
+  pod_token: Hex;
+  l1_token: Hex;
+  decimals: number;
+  /** Hex-encoded U256, in claim-chain decimals. */
+  min: string;
+  max: string;
+}
+
+export interface WireBridgeConfig {
+  claim_chain_id: number;
+  source_contract: Hex;
+  version: number;
+  tokens: WireBridgeToken[];
+}
+
+/** `pod_withdrawals` delivers an ARRAY of these per tick; the REST backfill
+ * serves the identical shape, so a backfilled outcome is indistinguishable
+ * from one that arrived live. */
+export interface WireWithdrawal {
+  withdrawal_id: Hex;
+  withdrawer: Hex;
+  to: Hex;
+  token: Hex;
+  /** Hex-encoded U256 in pod's 18 decimals — the amount as signed. */
+  amount: string;
+  /** Omitted (not null) when the withdrawal is claimable. */
+  error?: string | null;
+  timestamp_us: number;
+}
+
+/** `GET /v1/bridge/withdrawals/by-id/{id}`. Nested rather than flattened because
+ * `WithdrawalUpdate` carries a u128 and serde's `flatten` cannot round-trip one.
+ *
+ * `status` is always present and is the authority on which state this is; `proof`
+ * is omitted (never null) until a certificate can be assembled. */
+export interface WireWithdrawalDetail {
+  withdrawal: WireWithdrawal;
+  status: "claimable" | "pending" | "refused";
+  proof?: { claim_hash?: Hex | null };
+}

--- a/ts-sdk/src/types/wire.ts
+++ b/ts-sdk/src/types/wire.ts
@@ -421,8 +421,11 @@ export interface WireWithdrawal {
 /** `GET /v1/bridge/withdrawals/by-id/{id}`. Nested rather than flattened because
  * `WithdrawalUpdate` carries a u128 and serde's `flatten` cannot round-trip one.
  *
- * `status` is always present and is the authority on which state this is; `proof`
- * is omitted (never null) until a certificate can be assembled. */
+ * `status` is always present, but it is NOT what a consumer decides on: `proof`
+ * takes precedence, including over a `status` this build has never seen, so an
+ * unfamiliar label cannot veto a certificate attached to the same response.
+ * `proof` is omitted (never null) until one can be assembled. `fetchClaimStatus`
+ * carries the full precedence. */
 export interface WireWithdrawalDetail {
   withdrawal: WireWithdrawal;
   status: "claimable" | "pending" | "refused";

--- a/ts-sdk/src/write/delegation.ts
+++ b/ts-sdk/src/write/delegation.ts
@@ -13,6 +13,7 @@
 import { createWalletClient, defineChain, encodeFunctionData, http, parseAbi, recoverTypedDataAddress } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import type { Address, Hash, Hex } from "../types/public.js";
+import { rpc } from "../transport/jsonrpc.js";
 import { sendRawTransaction, type PodTxRequest } from "./index.js";
 
 /** EIP-712 payload the master signs (domain "pod delegation" v1). */
@@ -92,22 +93,11 @@ export async function createDelegatedWallet(p: CreateDelegatedWalletParams): Pro
       functionName: "delegated",
       args: [p.master, validUntil, signature, tx.data],
     });
-    const maxFeePerGas = BigInt(await rpc(p.rpcUrl, doFetch, "eth_gasPrice"));
+    const maxFeePerGas = BigInt(await rpc<string>(p.rpcUrl, "eth_gasPrice", [], { fetch: doFetch }));
     const prepared = await client.prepareTransactionRequest({ ...tx, data, account, chain, maxFeePerGas });
     const serialized = await client.signTransaction(prepared as never);
     return sendRawTransaction(p.rpcUrl, serialized, { fetch: doFetch });
   };
 
   return Object.freeze({ master: p.master, delegate: account.address, validUntil, submit });
-}
-
-async function rpc(rpcUrl: string, doFetch: typeof fetch, method: string): Promise<string> {
-  const res = await doFetch(rpcUrl, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [] }),
-  });
-  const json = (await res.json()) as { result?: string; error?: { message?: string } };
-  if (json.error || json.result === undefined) throw new Error(json.error?.message ?? `${method} failed`);
-  return json.result;
 }

--- a/ts-sdk/src/write/index.ts
+++ b/ts-sdk/src/write/index.ts
@@ -701,15 +701,22 @@ export interface ClobWithdrawParams {
   recipient: Address;
   /** 1e18-scaled, and a whole number of claim-chain units. */
   amount: bigint;
-  /** Auction interval in microseconds; floors the deadline like the order builders. */
-  auctionIntervalUs?: number;
+  /**
+   * Auction interval in microseconds (`market.auctionIntervalMs * 1000`).
+   *
+   * **Required, unlike the order builders'.** Admission refuses a deadline that
+   * is not a multiple of it, and the default here is a far-future timestamp with
+   * no reason to land on one — so an optional interval would silently produce a
+   * transaction that is rejected unless the clock happened to be aligned, and
+   * the rare one that slipped through would be stranded a decade out.
+   */
+  auctionIntervalUs: number;
   deadline?: number; // ms; default far future
 }
 
 export function buildClobWithdraw(p: ClobWithdrawParams): PodTxRequest {
   const nowUs = BigInt(Date.now()) * 1000n;
-  const interval = p.auctionIntervalUs ? BigInt(p.auctionIntervalUs) : 0n;
-  const deadline = alignDeadline(us(p.deadline, nowUs + FAR_US), interval);
+  const deadline = alignDeadline(us(p.deadline, nowUs + FAR_US), BigInt(p.auctionIntervalUs));
   const data = encodeFunctionData({
     abi: CLOB_ABI,
     functionName: "withdraw",

--- a/ts-sdk/src/write/index.ts
+++ b/ts-sdk/src/write/index.ts
@@ -13,6 +13,7 @@
 import { decodeAbiParameters, encodeAbiParameters, encodeFunctionData, keccak256, parseAbi } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import type { Address, Hash, Hex, MarketId } from "../types/public.js";
+import { rpc } from "../transport/jsonrpc.js";
 
 /** The CLOB precompile (chain id 1293 / 0x50d). */
 export const CLOB_ADDRESS: Address = "0x50d0000000000000000000000000000000000002";
@@ -26,6 +27,7 @@ const CLOB_ABI = parseAbi([
   "function cancelTrigger(bytes32 orderbookId, bytes32 triggerOrder, uint128 deadline)",
   "function updateTrigger(bytes32 orderbookId, bytes32 triggerOrder, int256 newSize, uint256 newLimitPrice, uint256 newTriggerPrice, uint128 deadline)",
   "function submitBatch(bytes[] inner)",
+  "function withdraw(address token, address recipient, uint256 amount, uint128 deadline)",
 ]);
 
 /** ~10 years in microseconds — default far-future expiry for resting orders. */
@@ -587,18 +589,9 @@ export interface MintParams {
  * on rejection (e.g. "Minting is disabled") and Error on on-chain revert. */
 export async function mint(p: MintParams): Promise<TxReceipt> {
   const doFetch = p.fetch ?? fetch;
-  const rpc = async (method: string): Promise<string> => {
-    const res = await doFetch(p.rpcUrl, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: [] }),
-    });
-    const json = (await res.json()) as { result?: string; error?: { message?: string } };
-    if (json.error || json.result === undefined) throw new Error(json.error?.message ?? `${method} failed`);
-    return json.result;
-  };
-  const chainId = p.chainId ?? Number(await rpc("eth_chainId"));
-  const maxFeePerGas = BigInt(await rpc("eth_gasPrice"));
+  const read = (method: string) => rpc<string>(p.rpcUrl, method, [], { fetch: doFetch });
+  const chainId = p.chainId ?? Number(await read("eth_chainId"));
+  const maxFeePerGas = BigInt(await read("eth_gasPrice"));
   const signer = privateKeyToAccount(generatePrivateKey());
   const data = encodeFunctionData({
     abi: MINT_ABI,
@@ -684,12 +677,58 @@ export function buildWaitlistDeposit(p: WaitlistDepositParams): SourceChainCall 
   };
 }
 
+// --- withdrawals (ADR 0033) --------------------------------------------------
+//
+// `Clob.withdraw` settles on L1 in ONE transaction: the CLOB balance is debited
+// straight to the bridge's custody and N−F validators sign the L1 claim at
+// solution execution. Nothing is credited to a pod account on the way, so the
+// legacy `Bridge.withdraw` rules — `tx.value == amount`, a gas reserve, a second
+// signature — do not apply, and MAX is the whole withdrawable balance.
+//
+// Two fields mean something different from the same-named ones elsewhere:
+//   - `recipient` is an address on the CLAIM chain, not on pod. Delegated calls
+//     stay pinned to the master (ADR 0018), so a session key cannot redirect it.
+//   - `amount` stays in pod's 18 decimals, but must be a whole number of
+//     claim-chain units or admission rejects it. Size it with `maxWithdrawable`
+//     / `quantizeWithdrawAmount` from `codec/bridge.ts` — this builder encodes
+//     what it is given and does no rounding of its own, because silently
+//     changing an amount a user signed for is worse than a clear rejection.
+
+export interface ClobWithdrawParams {
+  /** Pod-side token address (native USD for cash). */
+  token: Address;
+  /** Recipient on the **claim chain**. */
+  recipient: Address;
+  /** 1e18-scaled, and a whole number of claim-chain units. */
+  amount: bigint;
+  /** Auction interval in microseconds; floors the deadline like the order builders. */
+  auctionIntervalUs?: number;
+  deadline?: number; // ms; default far future
+}
+
+export function buildClobWithdraw(p: ClobWithdrawParams): PodTxRequest {
+  const nowUs = BigInt(Date.now()) * 1000n;
+  const interval = p.auctionIntervalUs ? BigInt(p.auctionIntervalUs) : 0n;
+  const deadline = alignDeadline(us(p.deadline, nowUs + FAR_US), interval);
+  const data = encodeFunctionData({
+    abi: CLOB_ABI,
+    functionName: "withdraw",
+    args: [p.token, p.recipient, p.amount, deadline],
+  }) as Hex;
+  return { to: CLOB_ADDRESS, data, value: 0n, type: "eip1559", maxPriorityFeePerGas: 0n, gas: 1_000_000n };
+}
+
 /**
  * Deterministic order id: `keccak256(abi.encode(signer, nonce, sequence))`,
  * matching the engine (`trading/src/lib.rs`). `sequence` is the 0-based index
  * of the intent within a `submitBatch` (0 for a single-intent tx). Needs the
  * nonce, so it's only known up-front in managed mode; in advisory mode reconcile
  * by `tx` from the `pod_orders_v2` stream instead.
+ *
+ * **This is also the `withdrawal_id`** that `pod_withdrawals` reports and that
+ * `GET /v1/bridge/withdrawals/by-id/{id}` is keyed on — same derivation, same
+ * intent identity (ADR 0033 §3). `signer` is whoever signed the transaction,
+ * i.e. the delegate under a session key, not the debited master.
  */
 export function deriveOrderId(signer: Address, nonce: number, sequence = 0): Hash {
   return keccak256(


### PR DESCRIPTION
Phase 6 of ADR 0033. `Clob.withdraw` moves a CLOB balance straight to the claim chain in one transaction — nothing is credited to a pod account on the way, so there is no second signature and no half-finished state to recover.

Adds four pieces: the write builder, the amount arithmetic, the outcome stream (`client.withdrawals(account)`, live plus REST backfill), and the claim watcher.

## The parts worth reviewing

**The deadline is not optional.** `buildClobWithdraw` takes the auction interval, because an unaligned deadline is refused at admission. A builder that defaults it lands roughly one transaction in five hundred and strands the rest ten years out.

**Amounts stay in pod's 18 decimals but must be a whole number of claim-chain units,** and the config's `min`/`max` are in the token's decimals rather than pod's. Where native USD maps to 6-decimal USDC, every withdrawal is a multiple of 1e12 wei. `maxWithdrawable` handles both ends; the builder deliberately rounds nothing, because silently changing a signed amount is worse than a clear rejection.

**The claim hash is fetched, never recomputed.** It folds in the pod chain id and the bridge version, so a local derivation is a second copy of a consensus-critical hash that stops matching after a version bump.

**`fetchClaimStatus` reads `proof` first and believes it whatever `status` says.** That ordering is the node's own consumer contract (`WithdrawalDetail` in `node/src/rpc/bridge_rest.rs`): a node that adds a fourth status while still attaching a certificate must not have it vetoed by a label this client has never heard of. Everything else, including a transport failure, is "ask again" rather than terminal.

**`watchClaims` follows many withdrawals on one pair of loops.** A `Claim` topic filter is an OR set at `topics[1]`, so a single `eth_getLogs` covers every outstanding hash and that query stops scaling with how many are in flight. The subtle half is the scan window: each id keeps its **own** floor and the shared query starts at the oldest, because a withdrawal still waiting for its certificate contributes no hash — yet the blocks passing meanwhile are exactly where its `Claim` may land, since a relayer can claim from a certificate this node has not finished assembling. Advancing on the strength of the ids that do have hashes loses that window permanently and silently.

**An unrecognised failure reason is carried through verbatim.** The node's reason enum is extensible and this package ships ahead of the fleet, so filtering to known spellings turns a *failed* withdrawal into a claimable-looking one — the caller then reports success and waits for an L1 event that can never fire.

## Verification

Exercised end to end against a local devnet with a real bridge on anvil: withdrawals submitted from both a script and the trading app, certificates assembled, and the relayer's claims confirmed on L1 with the amounts matching to the token's 6th decimal. The three-state by-id contract was checked against a live node, including that a `refused` response omits the `proof` key rather than sending `null`.

Topology was `FAULT_TOLERANCE=0` — one validator plus the solver, single peer, local anvil — so it says nothing about a real committee or a claim chain's reorg and finality behaviour.

## Release

Version is **0.4.0**; 0.3.0 is already published and on `main`. The frontend consumer (podnetwork/frontend) pins `^0.4.0` and cannot build until this ships, since caret pins the minor on 0.x.