### PR TITLE
docs: post-only orders and the flags-carrying submitOrder

### DIFF
--- a/doc/api-reference/applications-precompiles/README.md
+++ b/doc/api-reference/applications-precompiles/README.md
@@ -108,7 +108,7 @@ const abi = [
   `function submitOrder(
     bytes32 orderbookId, int256 size, uint256 price,
     uint8 orderType, uint128 deadline, uint128 ttl,
-    bool reduceOnly, bool ioc
+    uint8 flags
   )`
 ];
 const orderbook = new ethers.Contract(ORDERBOOK, abi, signer);
@@ -126,8 +126,7 @@ const ttl = 60n * 1_000_000n;                  // 60 seconds in microseconds
 
 const tx = await orderbook.submitOrder(
   orderbookId, size, price, orderType, deadline, ttl,
-  false,    // reduceOnly (perp only)
-  false,    // ioc — immediate-or-cancel
+  0,        // flags: 0x01 REDUCE_ONLY (perp only) | 0x02 IOC | 0x04 POST_ONLY
 );
 console.log("Order tx:", tx.hash);
 ```
@@ -149,8 +148,7 @@ abi = [{"inputs": [
     {"name": "orderType", "type": "uint8"},
     {"name": "deadline", "type": "uint128"},
     {"name": "ttl", "type": "uint128"},
-    {"name": "reduceOnly", "type": "bool"},
-    {"name": "ioc", "type": "bool"}],
+    {"name": "flags", "type": "uint8"}],
     "name": "submitOrder", "outputs": [],
     "stateMutability": "nonpayable", "type": "function"}]
 
@@ -169,8 +167,7 @@ tx = orderbook.functions.submitOrder(
     0,                                           # order type: 0 = Limit
     deadline,                                    # deadline in microseconds
     60 * 1_000_000,                              # ttl: 60 seconds
-    False,                                       # reduce only (perp only)
-    False,                                       # ioc (immediate-or-cancel)
+    0,                                           # flags: 0x01 REDUCE_ONLY | 0x02 IOC | 0x04 POST_ONLY
 ).build_transaction({
     "from": account.address,
     "nonce": w3.eth.get_transaction_count(account.address),
@@ -199,7 +196,7 @@ sol! {
         function submitOrder(
             bytes32 orderbookId, int256 size, uint256 price,
             OrderType orderType, uint128 deadline, uint128 ttl,
-            bool reduceOnly, bool ioc
+            uint8 flags
         ) public;
     }
 }
@@ -235,8 +232,7 @@ async fn main() -> eyre::Result<()> {
         Orderbook::OrderType::Limit,             // order type
         deadline,                                 // deadline (auction-tick aligned)
         60 * 1_000_000,                          // ttl: 60 seconds
-        false,                                    // reduceOnly (perp only)
-        false,                                    // ioc — immediate-or-cancel
+        0,                                        // flags: 0x01 REDUCE_ONLY | 0x02 IOC | 0x04 POST_ONLY
     ).send().await?;
 
     println!("Order tx: {:?}", tx.tx_hash());

--- a/doc/api-reference/applications-precompiles/orderbook.md
+++ b/doc/api-reference/applications-precompiles/orderbook.md
@@ -36,6 +36,59 @@ The alignment rule applies to **every deadline-bearing call** on this precompile
 See [Batch Deadline](../../protocol/orderbook.md#batch-deadline) in the protocol reference for the full discussion of `deadline` semantics and the trade-offs around `LAG`.
 {% endhint %}
 
+### Order flags
+
+`submitOrder` carries an order's boolean properties in a single `uint8 flags` bitfield rather than one `bool` argument per property. OR together the bits you want; `0` is a plain resting limit order.
+
+| Bit | Value  | Flag          | Meaning                                                                                                                                     |
+| --- | ------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | `0x01` | `REDUCE_ONLY` | The order may only reduce the submitter's existing position. Perp markets only.                                                              |
+| 1   | `0x02` | `IOC`         | Immediate-or-cancel: whatever does not match in the order's batch is cancelled at the end of it instead of resting on the book.              |
+| 2   | `0x04` | `POST_ONLY`   | Add-liquidity-only: the order rests, but may not trade in the batch that admitted it. See [Post-only orders](#post-only-orders).             |
+
+Combinations are checked when the intent is validated:
+
+* `IOC | POST_ONLY` is **rejected** (`post-only order cannot be immediate-or-cancel`) — IOC demands a fill in the admitting batch, post-only forbids one.
+* `POST_ONLY` on a `Market` order is **rejected** (`post-only is not valid for a market order`) — a market order has no resting price, so it has nothing to post at.
+* `REDUCE_ONLY | POST_ONLY` is fine, as is any other combination.
+* Market orders must set `IOC` (`market orders must be immediate-or-cancel`).
+
+{% hint style="warning" %}
+**Bits 3–7 must be zero.** Calldata carrying a flag bit the network does not recognise is rejected, not masked off — so an intent is never executed with a property silently dropped from it. Future order properties arrive as new bits here rather than as another overload.
+{% endhint %}
+
+{% hint style="info" %}
+**`submitOrder` is overloaded, and only the `flags` form is current.** Encode against the exact signature — the selector differs per overload:
+
+| Signature                                                                             | Selector     | Status                                                                                                                              |
+| ------------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `submitOrder(bytes32,int256,uint256,uint8,uint128,uint128,uint8)`                      | `0x1e416275` | **Current.** The `flags` form; the only one that can request post-only.                                                              |
+| `submitOrder(bytes32,int256,uint256,uint8,uint128,uint128,bool,bool)`                  | `0x435f7e71` | Deprecated. The old `reduceOnly, ioc` pair, still accepted; equivalent to setting bit 0 from `reduceOnly` and bit 1 from `ioc`.                         |
+| `submitOrder(bytes32,int256,uint256,uint8,uint128,uint128,bool)`                       | `0xc06f0480` | Retired. The `reduceOnly`-only form, rejected for any `deadline` at or after the network's configured legacy cutoff.                 |
+
+The `flags` overload can only be decoded by nodes that ship it, so a client that must also work against a network running an older build can keep emitting the deprecated `bool, bool` form — it is accepted unchanged, and it simply cannot request post-only.
+
+`submitTrigger` still takes `bool reduceOnly, bool ioc` and has no `flags` argument, so a trigger's synthetic order cannot be post-only.
+{% endhint %}
+
+### Post-only orders
+
+A post-only order is guaranteed to **add** liquidity: it rests on the book and never takes from it on the way in. Set `POST_ONLY` (`0x04`) in `flags`.
+
+Because pod matches in discrete batch auctions rather than on arrival, "would this order cross the book right now?" is the wrong question — every intent in a batch is matched together, so two orders that arrive in the same batch and match each other are *both* takers. The guarantee is therefore expressed against the batch:
+
+> **A post-only order may not trade in the batch that admitted it.** From the next batch onwards it is an ordinary resting maker and matches normally.
+
+What that means in practice:
+
+* The order enters the book immediately and is reported `active`, like any other resting order.
+* If it would have traded **in that first batch**, it is removed from the book instead. The removal is terminal and never partial — a refusal never leaves a post-only order half-filled — and it is reported with the terminal status `post_only_refused`, which is distinct from `canceled` so you can tell a refusal from a cancel you sent yourself.
+* If it would **not** have traded in that batch, nothing happens to it: it rests, and can be matched from the next batch on.
+* If another order at the same price with better queue priority absorbs the crossing liquidity first, your post-only order simply rests — it never had the opportunity to take, so there is nothing to refuse.
+* Two post-only orders admitted in the same batch that cross only each other are **both** refused. Neither took resting liquidity, but each would have taken from the other.
+
+**Amendments re-arm the guarantee.** An `update` that re-queues the order — a price change, or a size increase — makes it a newcomer again, so it may not trade for the rest of *that* batch and can be refused in it (for example, when you reprice it onto a crossing level). An update that only *decreases* the size keeps its queue priority and its original admission batch, so it goes on matching normally.
+
 ### Batch envelope
 
 `submitBatch` packs several single-intent calls (1–64) into a single signed transaction that lands atomically in one auction tick. Each entry in `inner` is the full ABI-encoded calldata of a single-intent function (`submitOrder`, `cancel`, `update`, `submitTrigger`, `deposit`, …) — encoded exactly as a standalone call, including its 4-byte selector. Every sub-intent **must carry the same `deadline`** (the uniform-deadline invariant), and nested batches are rejected. For the full rules and a worked example, see [Submit a batch order](../guides/submit-a-batch-order.md).
@@ -76,6 +129,14 @@ contract Orderbook {
 
     // --- Order Management ---
 
+    // Bits of `submitOrder`'s `flags` argument. OR together the ones you want;
+    // 0 is a plain resting limit order. Bits 3-7 are unassigned and MUST be
+    // zero — a node rejects calldata carrying a flag bit it does not know
+    // rather than ignoring it. New order properties become a new bit here.
+    uint8 constant REDUCE_ONLY = 0x01; // perp markets only
+    uint8 constant IOC         = 0x02;
+    uint8 constant POST_ONLY   = 0x04;
+
     /**
      * Submits a new order to the orderbook.
      * The direction of the trade (Bid/Ask) is determined by the sign of the size.
@@ -85,8 +146,26 @@ contract Orderbook {
      * @param orderType The order type (Limit or Market).
      * @param deadline The timestamp limit for this order to be included in a batch in microseconds. Must be a multiple of the market's `auction_interval`.
      * @param ttl The "Time To Live" duration in microseconds; how long the order remains active in the book.
-     * @param reduceOnly If true, this order will only reduce an existing position. Perp markets only.
-     * @param ioc If true, the order is Immediate-Or-Cancel: any unmatched portion is cancelled at the end of the batch instead of resting on the book.
+     * @param flags Bitfield of the order's properties — REDUCE_ONLY, IOC, POST_ONLY (see above).
+     *        IOC | POST_ONLY is rejected, as is POST_ONLY on a Market order.
+     */
+    function submitOrder(
+        bytes32 orderbookId,
+        int256 size,
+        uint256 price,
+        OrderType orderType,
+        uint128 deadline,
+        uint128 ttl,
+        uint8 flags
+    ) public {}
+
+    /**
+     * @notice Deprecated: the pre-`flags` form of `submitOrder`, kept so calldata
+     *         written against it still decodes. It cannot request POST_ONLY.
+     *         Equivalent to the current form with bit 0 set from `reduceOnly`
+     *         and bit 1 from `ioc`.
+     * @dev A third, retired overload — the same call without `ioc` — is rejected
+     *      for any `deadline` at or after the network's legacy cutoff.
      */
     function submitOrder(
         bytes32 orderbookId,

--- a/doc/api-reference/guides/delegate-a-trading-key.md
+++ b/doc/api-reference/guides/delegate-a-trading-key.md
@@ -39,7 +39,7 @@ const signature = await master.signTypedData(
 // 2. Delegate wraps an order in delegated(...) and submits it with its own key.
 const ORDERBOOK = "0x50d0000000000000000000000000000000000002";
 const abi = [
-  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, bool reduceOnly, bool ioc)",
+  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, uint8 flags)",
   "function delegated(address master, uint64 validUntil, bytes signature, bytes inner)",
 ];
 const orderbook = new ethers.Contract(ORDERBOOK, abi, delegate);
@@ -54,7 +54,7 @@ const ttl = 60n * 1_000_000n;
 // 5 NVDA long at $140 limit, owned by the master
 const inner = orderbook.interface.encodeFunctionData("submitOrder", [
   nvdaPerpId, ethers.parseEther("5"), ethers.parseEther("140"),
-  0 /* Limit */, deadline, ttl, false, false,
+  0 /* Limit */, deadline, ttl, 0 /* flags */,
 ]);
 
 const tx = await orderbook.delegated(master.address, validUntil, signature, inner);
@@ -83,7 +83,7 @@ sol! {
         function submitOrder(
             bytes32 orderbookId, int256 size, uint256 price,
             OrderType orderType, uint128 deadline, uint128 ttl,
-            bool reduceOnly, bool ioc
+            uint8 flags
         ) public;
         function delegated(address master, uint64 validUntil, bytes signature, bytes inner) public;
     }
@@ -131,7 +131,7 @@ let inner = Orderbook::submitOrderCall {
     size: I256::from_raw(U256::from(5) * one_e18),
     price: U256::from(140) * one_e18,
     orderType: Orderbook::OrderType::Limit,
-    deadline, ttl, reduceOnly: false, ioc: false,
+    deadline, ttl, flags: 0,
 }.abi_encode();
 
 let tx = orderbook

--- a/doc/api-reference/guides/place-a-perpetual-order.md
+++ b/doc/api-reference/guides/place-a-perpetual-order.md
@@ -22,8 +22,14 @@ const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
 const ORDERBOOK = "0x50d0000000000000000000000000000000000002";
 const abi = [
   "function deposit(address token, address recipient, uint256 amount, uint128 deadline)",
-  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, bool reduceOnly, bool ioc)",
+  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, uint8 flags)",
 ];
+
+// `flags` bits — OR together the ones you want, 0 for a plain resting limit order
+const REDUCE_ONLY = 0x01;
+const IOC = 0x02;
+const POST_ONLY = 0x04;
+
 const orderbook = new ethers.Contract(ORDERBOOK, abi, wallet);
 
 // USD is Pod's native token — use the canonical native-token sentinel address
@@ -49,8 +55,7 @@ const ttl = 60n * 1_000_000n;
 
 const tx = await orderbook.submitOrder(
   nvdaPerpId, size, price, orderType, deadline, ttl,
-  false,    // reduceOnly — set true to only close existing positions
-  false,    // ioc
+  0,        // flags — REDUCE_ONLY to only close, POST_ONLY to guarantee you add liquidity
 );
 console.log("Perp order tx:", tx.hash);
 ```
@@ -71,10 +76,15 @@ sol! {
         function submitOrder(
             bytes32 orderbookId, int256 size, uint256 price,
             OrderType orderType, uint128 deadline, uint128 ttl,
-            bool reduceOnly, bool ioc
+            uint8 flags
         ) public;
     }
 }
+
+// `flags` bits — OR together the ones you want, 0 for a plain resting limit order
+const REDUCE_ONLY: u8 = 0x01;
+const IOC: u8 = 0x02;
+const POST_ONLY: u8 = 0x04;
 
 let signer: PrivateKeySigner = PRIVATE_KEY.parse()?;
 let provider = ProviderBuilder::new()
@@ -115,8 +125,7 @@ let ttl = 60 * 1_000_000;
 let tx = orderbook
     .submitOrder(
         nvda_perp_id, size, price, Orderbook::OrderType::Limit, deadline, ttl,
-        false,        // reduceOnly — set true to only close existing positions
-        false,        // ioc
+        0,            // flags — REDUCE_ONLY to only close, POST_ONLY to guarantee you add liquidity
     )
     .send().await?;
 println!("Perp order tx: {:?}", tx.tx_hash());
@@ -126,7 +135,21 @@ println!("Perp order tx: {:?}", tx.tx_hash());
 
 ## Closing a position
 
-Submit an opposite-sided order with `reduceOnly = true`. Reduce-only orders can only decrease your existing exposure — they will be rejected if matching them would flip your position direction or open a new one.
+Submit an opposite-sided order with `REDUCE_ONLY` (`0x01`) set in `flags`. Reduce-only orders can only decrease your existing exposure — they will be rejected if matching them would flip your position direction or open a new one.
+
+## Market-making: guarantee that you add liquidity
+
+Set `POST_ONLY` (`0x04`) in `flags` to quote as a guaranteed maker. The order rests on the book as usual, but it may not trade in the batch that admitted it: if it would have taken liquidity in that batch, it is removed instead and reported with the terminal status `post_only_refused`. From the next batch onwards it matches like any other resting order.
+
+```typescript
+// A post-only, reduce-only quote: it can only add liquidity, and only close exposure
+const tx = await orderbook.submitOrder(
+  nvdaPerpId, size, price, orderType, deadline, ttl,
+  POST_ONLY | REDUCE_ONLY,
+);
+```
+
+`POST_ONLY` cannot be combined with `IOC`, and cannot be set on a market order — both are rejected. It also cannot be requested on a TP/SL trigger, since `submitTrigger` has no `flags` argument. See [Post-only orders](../applications-precompiles/orderbook.md#post-only-orders) for the exact rules, including what happens when two post-only orders cross each other and how amendments re-arm the guarantee.
 
 {% hint style="info" %}
 **Market leverage.** Each perp market has a fixed `maxLeverage` set at creation (20x on every testnet perp). It determines the margin required per position — there's no per-order leverage to set.

--- a/doc/api-reference/guides/place-a-spot-order.md
+++ b/doc/api-reference/guides/place-a-spot-order.md
@@ -2,7 +2,7 @@
 
 This guide walks through placing a limit order on one of Pod's spot markets. For background, see [Orderbook](https://docs.v2.pod.network/documentation/markets/orderbook).
 
-Spot orders use the same `submitOrder` call as perpetual orders. For spot, pass `reduceOnly = false` and `ioc = false` for a resting limit order. Deposit the quote token (USD) before submitting.
+Spot orders use the same `submitOrder` call as perpetual orders. Its `flags` argument carries the order's execution properties as a bitfield — pass `0` for a plain resting limit order. Deposit the quote token (USD) before submitting.
 
 The example below trades the NVDAx-USD spot market — see [Market Configurations](../market-configurations.md) for the full live list.
 
@@ -24,8 +24,14 @@ const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
 const ORDERBOOK = "0x50d0000000000000000000000000000000000002";
 const abi = [
   "function deposit(address token, address recipient, uint256 amount, uint128 deadline)",
-  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, bool reduceOnly, bool ioc)",
+  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, uint8 flags)",
 ];
+
+// `flags` bits — OR together the ones you want, 0 for a plain resting limit order
+const REDUCE_ONLY = 0x01; // perp only
+const IOC = 0x02;
+const POST_ONLY = 0x04;
+
 const orderbook = new ethers.Contract(ORDERBOOK, abi, wallet);
 
 // USD is the native token; NVDAx is the synthetic Nvidia base
@@ -51,8 +57,7 @@ const ttl = 60n * 1_000_000n;               // order lives for 60 seconds
 
 const tx = await orderbook.submitOrder(
   orderbookId, size, price, orderType, deadline, ttl,
-  false,    // reduceOnly (perp only)
-  false,    // ioc — immediate-or-cancel
+  0,        // flags — 0 rests on the book; POST_ONLY to guarantee you add liquidity
 );
 console.log("Order tx:", tx.hash);
 ```
@@ -73,10 +78,15 @@ sol! {
         function submitOrder(
             bytes32 orderbookId, int256 size, uint256 price,
             OrderType orderType, uint128 deadline, uint128 ttl,
-            bool reduceOnly, bool ioc
+            uint8 flags
         ) public;
     }
 }
+
+// `flags` bits — OR together the ones you want, 0 for a plain resting limit order
+const REDUCE_ONLY: u8 = 0x01; // perp only
+const IOC: u8 = 0x02;
+const POST_ONLY: u8 = 0x04;
 
 let signer: PrivateKeySigner = PRIVATE_KEY.parse()?;
 let provider = ProviderBuilder::new()
@@ -117,8 +127,7 @@ let ttl = 60 * 1_000_000; // order lives for 60 seconds
 let tx = orderbook
     .submitOrder(
         orderbook_id, size, price, Orderbook::OrderType::Limit, deadline, ttl,
-        false,        // reduceOnly (perp only)
-        false,        // ioc — immediate-or-cancel
+        0,            // flags — 0 rests on the book; POST_ONLY to guarantee you add liquidity
     )
     .send().await?;
 println!("Order tx: {:?}", tx.tx_hash());
@@ -129,3 +138,16 @@ println!("Order tx: {:?}", tx.tx_hash());
 {% hint style="warning" %}
 **Microseconds, not milliseconds.** Deadlines and TTLs are Unix timestamps in microseconds.
 {% endhint %}
+
+## Guarantee that you add liquidity
+
+Pass `POST_ONLY` (`0x04`) in `flags` to make the order a guaranteed maker. It rests on the book as usual, but it may not trade in the batch that admitted it: if it would have taken liquidity in that batch, it is removed instead and reported with the terminal status `post_only_refused`. From the next batch onwards it matches like any other resting order.
+
+```typescript
+const tx = await orderbook.submitOrder(
+  orderbookId, size, price, orderType, deadline, ttl,
+  POST_ONLY,
+);
+```
+
+`POST_ONLY` cannot be combined with `IOC`, and cannot be set on a market order — both are rejected. See [Post-only orders](../applications-precompiles/orderbook.md#post-only-orders) for the exact rules, including what happens when two post-only orders cross each other and how amendments re-arm the guarantee.

--- a/doc/api-reference/guides/submit-a-batch-order.md
+++ b/doc/api-reference/guides/submit-a-batch-order.md
@@ -23,10 +23,17 @@ const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
 
 const ORDERBOOK = "0x50d0000000000000000000000000000000000002";
 const abi = [
-  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, bool reduceOnly, bool ioc)",
+  "function submitOrder(bytes32 orderbookId, int256 size, uint256 price, uint8 orderType, uint128 deadline, uint128 ttl, uint8 flags)",
   "function submitTrigger(bytes32 orderbookId, int256 size, uint256 limitPrice, uint256 triggerPrice, uint8 triggerType, uint8 grouping, uint128 deadline, uint128 ttl, bool reduceOnly, bool ioc)",
   "function submitBatch(bytes[] inner)",
 ];
+
+// `submitOrder` flags bits. `submitTrigger` keeps its two booleans and has no
+// flags argument, so a trigger's synthetic order cannot be post-only.
+const REDUCE_ONLY = 0x01;
+const IOC = 0x02;
+const POST_ONLY = 0x04;
+
 const orderbook = new ethers.Contract(ORDERBOOK, abi, wallet);
 
 const nvdaPerpId = "0x0000000000000000000000000000000000000000000000000000000000000007"; // NVDA-USD perp
@@ -44,7 +51,7 @@ const size = ethers.parseEther("5"); // +5 NVDA long
 
 // 1. Entry: 5 NVDA long at $140 limit
 const entry = orderbook.interface.encodeFunctionData("submitOrder", [
-  nvdaPerpId, size, ethers.parseEther("140"), 0 /* Limit */, deadline, ttl, false, false,
+  nvdaPerpId, size, ethers.parseEther("140"), 0 /* Limit */, deadline, ttl, 0 /* flags */,
 ]);
 
 // 2. Take-profit: sell 5 NVDA when price reaches $160 (reduceOnly, tied to the position)
@@ -82,7 +89,7 @@ sol! {
         function submitOrder(
             bytes32 orderbookId, int256 size, uint256 price,
             OrderType orderType, uint128 deadline, uint128 ttl,
-            bool reduceOnly, bool ioc
+            uint8 flags
         ) public;
         function submitTrigger(
             bytes32 orderbookId, int256 size, uint256 limitPrice, uint256 triggerPrice,
@@ -124,7 +131,8 @@ let entry = Orderbook::submitOrderCall {
     size,
     price: U256::from(140) * one_e18,
     orderType: Orderbook::OrderType::Limit,
-    deadline, ttl, reduceOnly: false, ioc: false,
+    // flags — 0 rests on the book; POST_ONLY (0x04) to guarantee you add liquidity
+    deadline, ttl, flags: 0,
 }.abi_encode();
 
 // 2. Take-profit: sell 5 NVDA when price reaches $160 (reduceOnly, tied to the position)

--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -2461,7 +2461,7 @@ components:
 
     OrderStatus:
       type: string
-      enum: ["pending", "active", "filled", "expired", "canceled"]
+      enum: ["pending", "active", "filled", "expired", "canceled", "margin_canceled", "post_only_refused", "invalid"]
       description: |
         Current status of an order:
         - `pending`: Order submitted but not yet included in orderbook
@@ -2469,6 +2469,9 @@ components:
         - `filled`: Order completely filled
         - `expired`: Order expired (TTL exceeded)
         - `canceled`: Order was canceled by user
+        - `margin_canceled`: The engine removed the order because the owner's margin capacity was exhausted
+        - `post_only_refused`: The engine removed a `post_only` order that would have taken liquidity in the batch that admitted (or re-priced) it. Distinct from `canceled` so an engine refusal can be told apart from a cancel the trader sent — see [Post-only orders](https://docs.v2.pod.network/api-reference/applications-precompiles/orderbook)
+        - `invalid`: Rejected at execution and never entered the book; the reject reason travels with the status
 
     MarketType:
       type: string
@@ -2554,7 +2557,7 @@ components:
     Order:
       type: object
       description: |
-        An order returned by `ob_getOrders`. Carries spot and perp shapes — perp-only fields (`reduce_only`, `ioc`, `direction`) are present only when `market_type = perpetual`. The `initial_size` is signed: positive for Buy/Long, negative for Sell/Short.
+        An order returned by `ob_getOrders`. Carries spot and perp shapes — perp-only fields (`reduce_only`, `ioc`, `direction`) are present only when `market_type = perpetual`. `post_only` is reported on both. The `initial_size` is signed: positive for Buy/Long, negative for Sell/Short.
       properties:
         orderbook_id:
           $ref: '#/components/schemas/Bytes32'
@@ -2625,6 +2628,11 @@ components:
           type: boolean
           description: Perp only. Immediate-or-cancel — any unfilled remainder is canceled at end of batch. Omitted for spot orders.
           nullable: true
+        post_only:
+          type: boolean
+          description: |
+            Add-liquidity-only — the order could not trade in the batch that admitted it. Reported on
+            both market types, and **omitted when false**.
         direction:
           $ref: '#/components/schemas/OrderDirection'
           description: Composite direction label (set for spot, and for perps once fills land or for liquidation orders).
@@ -3393,8 +3401,15 @@ components:
           type: array
           items: { $ref: '#/components/schemas/OrderEventV2' }
           description: |
-            What happened, in a deterministic order: new/rejected orders, then fills ascending by
-            order id, then cancellations, expirations and modifications, then backstop sweeps.
+            What happened, in a deterministic order: new/rejected orders, then cancellations, then
+            modifications, then post-only refusals, then refused amendments, then fills ascending by
+            order id, then expirations, then backstop sweeps.
+
+            The order is not arbitrary: apply events as they arrive and your book is never transiently
+            wrong. Cancellations precede the fills so you never hold an order that has already been
+            removed, and post-only refusals sit **after** the modifications rather than with the other
+            cancellations, so an order repriced onto a crossing level and refused for it ends the frame
+            removed rather than resting at the refused price.
 
     OrderEntityV2:
       type: object
@@ -3463,6 +3478,11 @@ components:
         ioc:
           type: boolean
           description: 'Immediate-or-cancel. Omitted means false.'
+        post_only:
+          type: boolean
+          description: |
+            Add-liquidity-only — the order may not trade in the batch that admitted it, so it can rest
+            through a batch it appeared to cross. Omitted means false.
         trigger:
           type: string
           enum: [take_profit, stop_loss]
@@ -3489,7 +3509,8 @@ components:
             - `new` — the order entered the book.
             - `reject` — dropped during execution, never rested; `why` carries the reason.
             - `fill` — matched, wholly or partly.
-            - `cancel` — removed by a cancel intent or by the engine.
+            - `cancel` — removed by a cancel intent or by the engine. An engine removal carries `st`
+              (today only `post_only_refused`); a cancel the owner sent omits it.
             - `expire` — removed on reaching its TTL.
             - `modify` — a resting order's price and/or size changed in place.
             - `modify_reject` — an amendment the engine refused. The order is untouched; `code` says why.
@@ -3565,8 +3586,23 @@ components:
             on its first fill.
         st:
           type: string
-          enum: [filled, canceled, margin_canceled, expired]
-          description: '`fill` only, and only on the fill that **closed** the order, carrying the status it closed with. Its absence means the order is still working.'
+          enum: [filled, canceled, margin_canceled, expired, post_only_refused]
+          description: |
+            The terminal status an event closed the order with.
+
+            On `fill`: present only on the fill that **closed** the order; its absence there means the
+            order is still working.
+
+            On `cancel`: present only when the **engine** removed the order rather than the owner
+            cancelling it — today that is `post_only_refused`, a `post_only` order removed because it
+            would have taken liquidity in the batch that admitted or re-priced it. An ordinary cancel
+            omits `st`, so a client that ignores the field reads every `cancel` exactly as it did
+            before.
+
+            A refusal is ordered **after** the `modify` events in its frame, unlike every other cancel.
+            An order repriced onto a crossing level and refused for it emits `modify` and then `cancel`:
+            apply them in the order given and the order ends the frame removed, rather than resurrected
+            at the refused price.
         pa:
           type: string
           description: |
@@ -3598,7 +3634,10 @@ components:
         - `new` / `invalid`: the full `Order` fields are inlined alongside `type` (an `invalid`
           order was rejected at execution and never entered the book; the reason is on its
           `status`).
-        - `expired` / `canceled`: only `type` and `order_id` are present.
+        - `expired` / `canceled`: only `type` and `order_id` are present. This variant carries no
+          status, so an engine removal — such as a refused post-only order — is
+          indistinguishable from a cancel the trader sent. Use `pod_orders_v2`, whose `cancel` event
+          carries `st`, if you need to tell them apart.
         - `modified`: a resting order's price and/or size was changed in place by an `update`
           intent — `type`, `order_id`, and the new `new_price` / `new_size` are present.
         - `fill`: the `OrderFillUpdate` fields are inlined alongside `type`.

--- a/doc/protocol/orderbook.md
+++ b/doc/protocol/orderbook.md
@@ -14,6 +14,36 @@ The order book supports limit orders and market orders. The direction of a trade
 
 All markets use 1e18 tick sizes, matching the token decimal standard.
 
+### Execution flags
+
+Beyond its type, an order carries a small set of execution properties, submitted as the `flags` bitfield on `submitOrder`:
+
+| Flag          | Effect                                                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `REDUCE_ONLY` | The order may only reduce the submitter's existing position. Perpetual markets only.                                      |
+| `IOC`         | Immediate-or-cancel: whatever does not match in the order's batch is cancelled rather than resting. Market orders must set it. |
+| `POST_ONLY`   | Add-liquidity-only — see below.                                                                                           |
+
+A flag bit that a node does not recognise is rejected rather than ignored, so an order never executes with a property dropped from it. Bit values and the encoding rules are in the [Orderbook precompile reference](https://docs.v2.pod.network/api-reference/applications-precompiles/orderbook).
+
+### Post-only
+
+A post-only order is guaranteed to add liquidity rather than take it. Under frequent batch auctions that guarantee has to be stated against the batch, not against the book at arrival: every intent in a batch is matched simultaneously, so two orders that arrive in the same batch and match each other are both takers, however the book looked when either was submitted. Asking "does it cross right now?" would therefore not be enough to guarantee anything.
+
+So the rule is:
+
+> A post-only order may not trade in the batch that admitted it. From the next batch onwards it is an ordinary resting maker.
+
+What follows from it:
+
+* A post-only order that would have traded in its admitting batch is removed from the book instead. The removal is terminal and never partial, and it is reported under its own status, `post_only_refused`, so it is distinguishable from a cancel the trader sent.
+* One that would not have traded in that batch simply rests, and matches from the next batch on.
+* Two post-only orders admitted in the same batch that cross only each other are both refused: neither took resting liquidity, but each would have taken from the other.
+* If a same-price order with better queue priority absorbs the crossing liquidity first, the post-only order behind it rests untouched — it never had the chance to take.
+* Amending an order in a way that re-queues it (a new price, or a larger size) makes it a newcomer again for that batch; an amendment that only shrinks the order keeps its queue priority and goes on matching.
+
+A post-only order is therefore a *guaranteed maker* under a fee schedule that classifies maker and taker by the batch an order was included in: the classification cannot be gamed by an order that both arrived and traded in the same batch.
+
 ## Market Data
 
 The full node includes a built-in indexer for both live and historical market data. This provides order book snapshots, OHLCV candles, account-level order history, and position data without requiring users to run their own indexer. See the [`ob_` endpoints](https://docs.v2.pod.network/guides-references/json-rpc) in the JSON-RPC reference.


### PR DESCRIPTION
Documents the two user-visible changes from pod#1671 (`47a29111`): `submitOrder` now takes an order's execution properties as a `uint8 flags` bitfield instead of a bool per property, and post-only is a new property that guarantees an order adds liquidity.

## The flags bitfield

`REDUCE_ONLY 0x01`, `IOC 0x02`, `POST_ONLY 0x04`, OR'd together; `0` is a plain resting limit order. The precompile reference documents the bits, the combinations that are rejected (`IOC | POST_ONLY`, and `POST_ONLY` on a market order), and the fact that an unrecognised bit is rejected rather than masked off — so bits 3-7 must be zero.

It also carries an overload table, because `submitOrder` is overloaded three ways and each form has a different selector: the `flags` form `0x1e416275` is current and is the only one that can request post-only, the `bool, bool` form `0x435f7e71` is deprecated but still accepted, and the `reduceOnly`-only form `0xc06f0480` is rejected past the network's legacy cutoff. A client that must also work against a network on an older build can keep emitting the deprecated form.

Every code sample across the guides moves to the `flags` form — the spot, perpetual, batch and delegation guides, and the three language examples on the precompiles index page.

## Post-only

The guarantee is stated against the batch rather than the book at arrival, because every intent in a batch is matched simultaneously, so two orders that arrive in the same batch and match each other are both takers however the book looked when either was submitted. The rule the docs give is that a post-only order may not trade in the batch that admitted it, and is an ordinary resting maker from the next batch onwards.

Documented consequences: a refusal is terminal and never partial and is reported under its own `post_only_refused` status rather than as a plain cancel; two post-only orders that cross only each other are both refused; a same-price order with better queue priority absorbing the liquidity first leaves the post-only order resting; and an amendment that re-queues an order (new price, or larger size) re-arms the guarantee for that batch while a pure size decrease does not.

## Read side

`openapi.yaml` gains `post_only` on the `ob_getOrders` order and the `pod_orders_v2` entity, `post_only_refused` in `OrderStatus` and in the `st` enum, and `st` documented on `cancel` as well as `fill`. `OrderStatus` was also missing `margin_canceled` and `invalid`, both of which are already valid filter values, so they are added alongside. The v1 `pod_orders` limitation is called out: its cancel notification has no status, so a refusal is indistinguishable from a trader's own cancel there.

## Out of scope, worth flagging

`ts-sdk` still declares the `bool, bool` overload, so no SDK consumer can set `POST_ONLY` yet — only a hand-rolled encoder can. That is a separate change.
