### PR TITLE
fix(ts-sdk): read chart history as a one-shot, not through the live series

### DIFF
--- a/ts-sdk/README.md
+++ b/ts-sdk/README.md
@@ -48,6 +48,11 @@ const ob = useSyncExternalStore(
 
 - **Layer 1 (low-level, exposed):** `client.rest.*` typed one-shot reads and
   `client.ws.subscribe(channel, params, onMessage)` raw subscriptions.
+- **One-shot reads:** `client.candleHistory(id, resolution, range)` for chart
+  history (resolves with the whole window or rejects — a partial answer is worse
+  than an error, because a chart never re-asks) and `.candleTail(id, resolution,
+  range)` for the still-forming bucket, plus `.leaderboard(query)`,
+  `.transaction(hash)`.
 - **Layer 2 (resources):** `client.status`, `.markets`, `.market(id)`,
   `.orderbook(id,{depth})`, `.positions(account)`, `.triggers(account)`,
   `.backstopTransfers(account)`, `.candles(id, resolution, range)` (a

--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -1,5 +1,5 @@
 import type {
-  Address, BackstopTransfer, Balances, BridgeConfig, LeaderboardPage, LeaderboardQuery, Market,
+  Address, BackstopTransfer, Balances, Bar, BridgeConfig, LeaderboardPage, LeaderboardQuery, Market,
   MarketId, PositionsSnapshot, Resolution, Status, TimeRange, Trigger, TriggersQuery, TxExplorer,
   OrdersQuery, Withdrawal,
 } from "./types/public.js";
@@ -11,7 +11,7 @@ import {
   statusSource, triggersSource, type MarketsCache, type SyncContext,
 } from "./sync/sources.js";
 import { withdrawalsSource } from "./sync/withdrawals.js";
-import { CandleSeries } from "./sync/candles.js";
+import { CandleSeries, fetchCandleHistory } from "./sync/candles.js";
 import { OrderHistory } from "./sync/orders.js";
 import { enrichPositions } from "./sync/positions-live.js";
 
@@ -235,6 +235,57 @@ export class PodTradeClient {
     );
     if (range) series.setWindow(range);
     return series;
+  }
+
+  /**
+   * Closed bars for a window — a one-shot read, not a live resource.
+   *
+   * Chart history belongs here rather than on a `CandleSeries`: series are
+   * memoised per (market, resolution) and shared with whatever else is watching
+   * that market, so a history read that waited on the series' loading state
+   * could be resolved by an unrelated load finishing and report "no bars" for a
+   * window whose own pages were still in flight. This read owns its request:
+   * it resolves with the window's bars or rejects.
+   */
+  candleHistory(id: MarketId, resolution: Resolution, range: TimeRange): Promise<Bar[]> {
+    return fetchCandleHistory(this.ctx.rest, id, resolution, range);
+  }
+
+  /**
+   * The bars the live tick fold currently holds inside `range`, the forming
+   * bucket included — the other half of `candleHistory`, which can only ever
+   * return closed bars because REST withholds the open bucket.
+   *
+   * A chart asking for a window that reaches "now" on a market whose only
+   * activity is in that bucket has no closed history at all, and answering it
+   * "no bars" makes the chart latch the range as empty. Both datafeeds fall
+   * back to this instead.
+   *
+   * Subscribes for the wait rather than calling `ready()`: `ready()` starts the
+   * resource without registering a listener, so nothing would ever stop its
+   * WS fold again.
+   */
+  async candleTail(
+    id: MarketId,
+    resolution: Resolution,
+    range: TimeRange,
+    timeoutMs = 1_500,
+  ): Promise<Bar[]> {
+    // No range: this must not call setWindow on a series someone else is live on.
+    const series = this.candles(id, resolution);
+    const release = series.subscribe(() => {});
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        series.ready(),
+        new Promise((resolve) => { timer = setTimeout(resolve, timeoutMs); }),
+      ]);
+      const toMs = range.to ?? Date.now();
+      return (series.get() ?? []).filter((b) => b.time >= range.from && b.time < toMs);
+    } finally {
+      clearTimeout(timer);
+      release();
+    }
   }
 
   orders(account: Address, query?: OrdersQuery): OrderHistory {

--- a/ts-sdk/src/client.ts
+++ b/ts-sdk/src/client.ts
@@ -11,7 +11,7 @@ import {
   statusSource, triggersSource, type MarketsCache, type SyncContext,
 } from "./sync/sources.js";
 import { withdrawalsSource } from "./sync/withdrawals.js";
-import { CandleSeries, fetchCandleHistory } from "./sync/candles.js";
+import { CandleSeries, candleTailFrom, fetchCandleHistory } from "./sync/candles.js";
 import { OrderHistory } from "./sync/orders.js";
 import { enrichPositions } from "./sync/positions-live.js";
 
@@ -261,9 +261,9 @@ export class PodTradeClient {
    * "no bars" makes the chart latch the range as empty. Both datafeeds fall
    * back to this instead.
    *
-   * Subscribes for the wait rather than calling `ready()`: `ready()` starts the
-   * resource without registering a listener, so nothing would ever stop its
-   * WS fold again.
+   * Subscribes for the wait rather than calling `ready()`, which both starts the
+   * resource without registering a listener (nothing would ever stop its WS fold
+   * again) and resolves on the empty seed — see `candleTailFrom`.
    */
   async candleTail(
     id: MarketId,
@@ -274,16 +274,9 @@ export class PodTradeClient {
     // No range: this must not call setWindow on a series someone else is live on.
     const series = this.candles(id, resolution);
     const release = series.subscribe(() => {});
-    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      await Promise.race([
-        series.ready(),
-        new Promise((resolve) => { timer = setTimeout(resolve, timeoutMs); }),
-      ]);
-      const toMs = range.to ?? Date.now();
-      return (series.get() ?? []).filter((b) => b.time >= range.from && b.time < toMs);
+      return await candleTailFrom(series, range, timeoutMs);
     } finally {
-      clearTimeout(timer);
       release();
     }
   }

--- a/ts-sdk/src/codec/resolution.ts
+++ b/ts-sdk/src/codec/resolution.ts
@@ -1,6 +1,9 @@
 import type { Resolution } from "../types/public.js";
 
-/** Bucket width per resolution, in seconds. 1M is calendar-variable; see pages. */
+/**
+ * Bucket width per resolution, in seconds — the widths the server buckets by,
+ * which every page boundary here is derived from.
+ */
 export const RESOLUTION_SECONDS: Record<Resolution, number> = {
   "1m": 60,
   "5m": 300,
@@ -10,7 +13,7 @@ export const RESOLUTION_SECONDS: Record<Resolution, number> = {
   "4h": 14_400,
   "1d": 86_400,
   "1W": 604_800,
-  "1M": 2_592_000, // nominal 30d; only used as a hint, pages use calendar months
+  "1M": 2_592_000, // a nominal 30d month: what the indexer buckets by, not calendar months
 };
 
 /**

--- a/ts-sdk/src/codec/resolution.ts
+++ b/ts-sdk/src/codec/resolution.ts
@@ -32,7 +32,7 @@ export const RESOLUTION_PAGE_BUCKETS: Record<Resolution, number> = {
   "4h": 180, // ~30 days
   "1d": 365, // ~1 year
   "1W": 260, // ~5 years
-  "1M": 120, // ~decade (calendar-month buckets)
+  "1M": 120, // ~decade (nominal 30-day buckets, epoch-anchored — see above)
 };
 
 export const RESOLUTIONS = Object.keys(RESOLUTION_SECONDS) as Resolution[];

--- a/ts-sdk/src/datafeed.ts
+++ b/ts-sdk/src/datafeed.ts
@@ -56,15 +56,14 @@ export function createPodDatafeed(client: PodTradeClient): unknown {
       try {
         const id = (symbolInfo.ticker ?? symbolInfo.name) as MarketId;
         const res = TV_TO_RESOLUTION[resolution] ?? "1h";
-        const series = client.candles(id, res, {
-          from: periodParams.from * 1000,
-          to: periodParams.to * 1000,
-        });
-        const bars = await series.ready();
-        const inRange = bars
-          .filter((b) => b.time >= periodParams.from * 1000 && b.time < periodParams.to * 1000)
-          .map((b) => toTvBar(b));
-        onResult(inRange, { noData: inRange.length === 0 });
+        // One-shot read, never the memoised series — see client.candleHistory.
+        const range = { from: periodParams.from * 1000, to: periodParams.to * 1000 };
+        let bars = await client.candleHistory(id, res, range);
+        // Nothing closed yet in a window reaching now: the forming bucket is all
+        // this market has, and `noData` would make TV stop asking for it.
+        if (!bars.length && range.to > Date.now()) bars = await client.candleTail(id, res, range);
+        const tv = bars.map((b) => toTvBar(b));
+        onResult(tv, { noData: tv.length === 0 });
       } catch (e) {
         onError(String(e));
       }

--- a/ts-sdk/src/datafeed.ts
+++ b/ts-sdk/src/datafeed.ts
@@ -5,6 +5,7 @@
 import type { PodTradeClient } from "./client.js";
 import type { Bar, MarketId, Resolution } from "./types/public.js";
 import { toNumber } from "./codec/units.js";
+import { RESOLUTION_SECONDS } from "./codec/resolution.js";
 
 const TV_TO_RESOLUTION: Record<string, Resolution> = {
   "1": "1m", "5": "5m", "15": "15m", "30": "30m",
@@ -59,9 +60,15 @@ export function createPodDatafeed(client: PodTradeClient): unknown {
         // One-shot read, never the memoised series — see client.candleHistory.
         const range = { from: periodParams.from * 1000, to: periodParams.to * 1000 };
         let bars = await client.candleHistory(id, res, range);
-        // Nothing closed yet in a window reaching now: the forming bucket is all
-        // this market has, and `noData` would make TV stop asking for it.
-        if (!bars.length && range.to > Date.now()) bars = await client.candleTail(id, res, range);
+        // Nothing closed in a window that reaches into the forming bucket: that
+        // bucket is all this market has, and `noData` would make TV stop asking
+        // for it. Tested against the bucket, not `Date.now()`: TV rounds `to` to
+        // whole seconds, so a window covering the open bucket can still end a
+        // few hundred ms in the past.
+        const bucketMs = RESOLUTION_SECONDS[res] * 1000;
+        if (!bars.length && range.to > Math.floor(Date.now() / bucketMs) * bucketMs) {
+          bars = await client.candleTail(id, res, range);
+        }
         const tv = bars.map((b) => toTvBar(b));
         onResult(tv, { noData: tv.length === 0 });
       } catch (e) {

--- a/ts-sdk/src/stores/resource.ts
+++ b/ts-sdk/src/stores/resource.ts
@@ -5,6 +5,13 @@
 export interface Resource<T> {
   get(): T | undefined;
   subscribe(listener: () => void): () => void;
+  /**
+   * Resolves on the FIRST value the source commits — which for a resource that
+   * seeds progressively is the initial, possibly empty, seed and not "fully
+   * loaded". Do not use it to decide that a window has finished loading (that
+   * mistake drew empty charts); for a bounded read that must be complete, use a
+   * one-shot call such as `client.candleHistory`.
+   */
   ready(): Promise<T>;
   /** Restart the source for a fresh seed (optional — see BaseResource). */
   refresh?(): void;
@@ -62,7 +69,13 @@ export class BaseResource<T> implements Resource<T> {
     return this.readyPromise;
   }
 
-  /** Force teardown (used by the client on close). */
+  /**
+   * Force teardown, ignoring the subscriber count — for `client.close()`, not
+   * for one consumer that is done with a shared resource. Resources are
+   * memoised per key, so destroying one another consumer still holds stops its
+   * source underneath it; releasing your `subscribe()` teardown is enough,
+   * since the last one out stops the source anyway.
+   */
   destroy(): void {
     this.stop();
   }

--- a/ts-sdk/src/sync/candles.test.ts
+++ b/ts-sdk/src/sync/candles.test.ts
@@ -132,6 +132,23 @@ describe("fetchCandleHistory", () => {
     expect(got.at(-1)!.time).toBe(T0);
   });
 
+  it("rejects when a dropped old page leaves nothing to show", async () => {
+    // The trap: a quiet stretch next to a shed page. Slicing the failed prefix
+    // off leaves an empty array, which a chart reads as "no bars here, stop
+    // asking" — hiding the shed page's bars for as long as it lives.
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const oldest = Math.floor((T0 - 699 * MIN) / pageMs) * pageMs;
+    const { rest } = restStub(
+      // Only the oldest page has any trades in it, and that page fails.
+      bars.filter((b) => b.time < oldest + pageMs),
+      { fail: (from) => from === oldest },
+    );
+    await expect(
+      fetchCandleHistory(rest, ID, "1m", { from: T0 - 699 * MIN, to: T0 + MIN }, T0 + MIN),
+    ).rejects.toThrow(/failed/);
+  });
+
   it("rejects a gap that would sit between bars it is returning", async () => {
     const bars = series1m(700);
     const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;

--- a/ts-sdk/src/sync/candles.test.ts
+++ b/ts-sdk/src/sync/candles.test.ts
@@ -167,6 +167,27 @@ describe("candleTailFrom", () => {
     expect(listeners.size).toBe(0); // and it lets go of the series again
   });
 
+  it("releases its listener when the series emits inside subscribe()", async () => {
+    // `subscribe` starts the source, and the first `rebuild()` runs before its
+    // first await — so the listener can fire while it is still being registered.
+    let bars: Bar[] = [];
+    const listeners = new Set<() => void>();
+    const series = {
+      get: () => bars,
+      ready: async () => bars,
+      subscribe: (l: () => void) => {
+        listeners.add(l);
+        bars = [bar(T0)];
+        l(); // synchronous emit, before `subscribe` has returned
+        return () => listeners.delete(l);
+      },
+      loading: () => false, error: undefined,
+      setWindow: () => {}, loadOlder: async () => {}, hasMore: () => false,
+    } as unknown as SeriesResource<Bar>;
+    expect((await candleTailFrom(series, { from: T0, to: T0 + MIN }, 2_000)).map((b) => b.time)).toEqual([T0]);
+    expect(listeners.size).toBe(0); // and the tick fold is not left running
+  });
+
   it("gives up at the timeout instead of hanging the caller", async () => {
     const { series, listeners } = stubSeries();
     expect(await candleTailFrom(series, { from: T0, to: T0 + MIN }, 20)).toEqual([]);
@@ -214,6 +235,42 @@ describe("page cache", () => {
     const got = await fetchCandleHistory(rest, ID, "1m", range, T0 + MIN);
     expect(asks).toBe(2); // the short answer was not taken as final
     expect(got.at(-1)!.time).toBe(range.to - MIN);
+  });
+
+  it("does not retry the trailing page for being short — that is its normal state", async () => {
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const page = Math.floor(bars[0]!.time / pageMs) + 1;
+    // A clock mid-page, so the trailing window is clamped and cannot be whole.
+    const nowMs = page * pageMs + 10 * MIN;
+    let asks = 0;
+    const rest = {
+      candles: async (_id: MarketId, q: { from: number; to: number }) => {
+        asks += 1;
+        const solutionNow = q.to - MIN; // behind the window's end, as a lagging indexer is
+        return { bars: bars.filter((b) => b.time >= q.from && b.time < q.to), solutionNow };
+      },
+    } as unknown as PodRestClient;
+    await fetchCandleHistory(rest, ID, "1m", { from: page * pageMs, to: nowMs }, nowMs);
+    expect(asks).toBe(1); // no spin, no seconds of backoff against a healthy node
+  });
+
+  it("claims only what the indexer had reached, not every bar it was handed", async () => {
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const page = Math.floor(bars[0]!.time / pageMs) + 1;
+    const nowMs = page * pageMs + 10 * MIN;
+    const watermark = page * pageMs + 4 * MIN;
+    const rest = {
+      // A server that answers past its own watermark: the read must not pass
+      // those bars off as covered history.
+      candles: async (_id: MarketId, q: { from: number; to: number }) => ({
+        bars: bars.filter((b) => b.time >= q.from && b.time < q.to),
+        solutionNow: watermark,
+      }),
+    } as unknown as PodRestClient;
+    const got = await fetchCandleHistory(rest, ID, "1m", { from: page * pageMs, to: nowMs }, nowMs);
+    expect(got.at(-1)!.time).toBe(watermark - MIN);
   });
 
   it("never stores a page the indexer had not caught up to", async () => {

--- a/ts-sdk/src/sync/candles.test.ts
+++ b/ts-sdk/src/sync/candles.test.ts
@@ -16,7 +16,9 @@ import { RESOLUTION_PAGE_BUCKETS, RESOLUTION_SECONDS } from "../codec/resolution
 import type { PodRestClient } from "../transport/rest.js";
 import type { Bar, MarketId, Resolution } from "../types/public.js";
 import { PodHttpError } from "../transport/rest.js";
-import { candlePageWindows, CandleSeries, fetchCandleHistory } from "./candles.js";
+import {
+  candlePageWindows, CandleSeries, candleTailFrom, fetchCandleHistory, type SeriesResource,
+} from "./candles.js";
 import type { SyncContext } from "./sources.js";
 
 const ID = `0x${"8".padStart(64, "0")}` as MarketId;
@@ -141,6 +143,44 @@ describe("fetchCandleHistory", () => {
   });
 });
 
+describe("candleTailFrom", () => {
+  /** A series whose bars arrive after the caller starts waiting, and whose
+   * `ready()` resolves on the empty seed the way the real one does. */
+  const stubSeries = () => {
+    let bars: Bar[] = [];
+    const listeners = new Set<() => void>();
+    const series = {
+      get: () => bars,
+      ready: async () => bars,
+      subscribe: (l: () => void) => { listeners.add(l); return () => listeners.delete(l); },
+      loading: () => false, error: undefined,
+      setWindow: () => {}, loadOlder: async () => {}, hasMore: () => false,
+    } as unknown as SeriesResource<Bar>;
+    return { series, listeners, push: (next: Bar[]) => { bars = next; listeners.forEach((l) => l()); } };
+  };
+
+  it("waits for a bar in the window rather than taking the empty seed", async () => {
+    const { series, listeners, push } = stubSeries();
+    const pending = candleTailFrom(series, { from: T0, to: T0 + MIN }, 2_000);
+    push([bar(T0)]); // the forming bucket lands a beat after the call
+    expect((await pending).map((b) => b.time)).toEqual([T0]);
+    expect(listeners.size).toBe(0); // and it lets go of the series again
+  });
+
+  it("gives up at the timeout instead of hanging the caller", async () => {
+    const { series, listeners } = stubSeries();
+    expect(await candleTailFrom(series, { from: T0, to: T0 + MIN }, 20)).toEqual([]);
+    expect(listeners.size).toBe(0);
+  });
+
+  it("ignores bars outside the window", async () => {
+    const { series, push } = stubSeries();
+    const pending = candleTailFrom(series, { from: T0, to: T0 + MIN }, 60);
+    push([bar(T0 - 5 * MIN)]); // older than the window: keep waiting, then time out
+    expect(await pending).toEqual([]);
+  });
+});
+
 describe("page cache", () => {
   it("serves a repeat read of a final page without asking again", async () => {
     const bars = series1m(700);
@@ -152,6 +192,28 @@ describe("page cache", () => {
     expect(second.map((b) => b.time)).toEqual(first.map((b) => b.time));
     // Only the trailing (still-growing) page is re-asked; the full pages are not.
     expect(asked.length - asksAfterFirst).toBeLessThan(asksAfterFirst);
+  });
+
+  it("retries a window the indexer had not reached, instead of answering short", async () => {
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const page = Math.floor(bars[0]!.time / pageMs) + 1;
+    const range = { from: page * pageMs, to: (page + 1) * pageMs };
+    let asks = 0;
+    const rest = {
+      candles: async (_id: MarketId, q: { from: number; to: number }) => {
+        asks += 1;
+        // First answer is behind the window's end; the indexer catches up after.
+        const solutionNow = asks === 1 ? range.to - 10 * MIN : Number.MAX_SAFE_INTEGER;
+        return {
+          bars: bars.filter((b) => b.time >= q.from && b.time < q.to && b.time < solutionNow),
+          solutionNow,
+        };
+      },
+    } as unknown as PodRestClient;
+    const got = await fetchCandleHistory(rest, ID, "1m", range, T0 + MIN);
+    expect(asks).toBe(2); // the short answer was not taken as final
+    expect(got.at(-1)!.time).toBe(range.to - MIN);
   });
 
   it("never stores a page the indexer had not caught up to", async () => {

--- a/ts-sdk/src/sync/candles.test.ts
+++ b/ts-sdk/src/sync/candles.test.ts
@@ -1,0 +1,211 @@
+// Candle reads have one hard rule: a chart takes the answer to a history
+// request as the truth for that range and never asks again. So a read must
+// either deliver its whole window or fail loudly — a short answer is worse than
+// an error, because nothing detects it. Two bugs came from breaking that:
+//
+//   - history waited on the memoised `CandleSeries`' single `loading()` flag, so
+//     an unrelated load finishing resolved it with pages still in flight. The
+//     bars arrived (HTTP 200) and the chart drew a hole where they belonged.
+//   - a page whose fetch failed was stored as an empty page, which is
+//     indistinguishable from "no bars here" — so the hole was permanent: later
+//     loads only fetch pages they don't already have.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { RESOLUTION_PAGE_BUCKETS, RESOLUTION_SECONDS } from "../codec/resolution.js";
+import type { PodRestClient } from "../transport/rest.js";
+import type { Bar, MarketId, Resolution } from "../types/public.js";
+import { PodHttpError } from "../transport/rest.js";
+import { candlePageWindows, CandleSeries, fetchCandleHistory } from "./candles.js";
+import type { SyncContext } from "./sources.js";
+
+const ID = `0x${"8".padStart(64, "0")}` as MarketId;
+const MIN = 60_000;
+const T0 = Date.UTC(2026, 7, 19, 12, 0, 0); // a fixed "now", so no wall clock leaks in
+
+const bar = (time: number): Bar =>
+  ({ time, open: 1n, high: 1n, low: 1n, close: 1n, volume: 0n, quoteVolume: 0n });
+const series1m = (count: number, end = T0) =>
+  Array.from({ length: count }, (_, i) => bar(end - (count - 1 - i) * MIN));
+
+/**
+ * REST stub over a fixed bar set; records the windows asked for. `solutionNow`
+ * is the indexer watermark the real endpoint returns, and it truncates the
+ * answer the way the server does — bars past it are not indexed yet.
+ */
+const restStub = (bars: Bar[], opts: { fail?: (from: number) => boolean | Error; solutionNow?: number } = {}) => {
+  const asked: { from: number; to: number }[] = [];
+  const state = { solutionNow: opts.solutionNow ?? Number.MAX_SAFE_INTEGER };
+  const rest = {
+    candles: async (_id: MarketId, q: { from: number; to: number }) => {
+      asked.push({ from: q.from, to: q.to });
+      const fail = opts.fail?.(q.from);
+      if (fail) throw fail instanceof Error ? fail : new Error(`page ${q.from} failed`);
+      return {
+        bars: bars.filter((b) => b.time >= q.from && b.time < q.to && b.time < state.solutionNow),
+        solutionNow: state.solutionNow,
+      };
+    },
+  } as unknown as PodRestClient;
+  return { rest, asked, state };
+};
+
+describe("candlePageWindows", () => {
+  const pageMs = (res: Resolution) => RESOLUTION_PAGE_BUCKETS[res] * RESOLUTION_SECONDS[res] * 1000;
+
+  it("tiles the range on epoch-anchored pages, so URLs repeat across requests", () => {
+    const narrow = candlePageWindows("1m", T0 - 30 * MIN, T0, T0 + MIN);
+    const wide = candlePageWindows("1m", T0 - 5 * 60 * MIN, T0, T0 + MIN);
+    for (const w of [...narrow, ...wide]) {
+      expect(w.fromMs % pageMs("1m")).toBe(0); // anchored: same grid every time
+      expect(w.toMs - w.fromMs).toBeLessThanOrEqual(pageMs("1m"));
+    }
+    // The page they share is byte-identical, which is what makes the server's
+    // `immutable` response reusable from cache.
+    expect(wide.at(-1)).toEqual(narrow.at(-1));
+    // Consecutive pages meet exactly: no gap, no overlap.
+    for (let i = 1; i < wide.length; i++) expect(wide[i]!.fromMs).toBe(wide[i - 1]!.toMs);
+  });
+
+  it("clamps the trailing window to the last closed bucket", () => {
+    const now = T0 + 3 * MIN + 20_000; // mid-bucket
+    const [w] = candlePageWindows("1m", T0, T0 + 10 * MIN, now);
+    expect(w!.toMs).toBe(T0 + 3 * MIN); // the forming bucket is never requested
+  });
+
+  it("yields nothing when the range holds only the forming bucket", () => {
+    expect(candlePageWindows("1m", T0, T0 + MIN, T0 + 20_000)).toEqual([]);
+  });
+});
+
+describe("fetchCandleHistory", () => {
+  it("returns every bar in the window, in order, across pages", async () => {
+    const bars = series1m(700); // more than one 1m page (360 buckets)
+    const { rest, asked } = restStub(bars);
+    const got = await fetchCandleHistory(rest, ID, "1m", { from: T0 - 699 * MIN, to: T0 + MIN }, T0 + MIN);
+    expect(asked.length).toBeGreaterThan(1);
+    expect(got.map((b) => b.time)).toEqual(bars.map((b) => b.time));
+  });
+
+  it("excludes bars outside the window", async () => {
+    const { rest } = restStub(series1m(700));
+    const got = await fetchCandleHistory(rest, ID, "1m", { from: T0 - 9 * MIN, to: T0 - 4 * MIN }, T0 + MIN);
+    expect(got.map((b) => b.time)).toEqual([9, 8, 7, 6, 5].map((n) => T0 - n * MIN));
+  });
+
+  it("retries a page that fails once, and still completes the window", async () => {
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const oldest = Math.floor((T0 - 699 * MIN) / pageMs) * pageMs;
+    const { rest, asked } = restStub(bars, {
+      // Fails only the first attempt at that page — a cold window on a busy node.
+      fail: (from) => from === oldest && asked.filter((a) => a.from === from).length === 1,
+    });
+    const got = await fetchCandleHistory(rest, ID, "1m", { from: T0 - 699 * MIN, to: T0 + MIN }, T0 + MIN);
+    expect(got.map((b) => b.time)).toEqual(bars.map((b) => b.time));
+    expect(asked.filter((a) => a.from === oldest)).toHaveLength(2);
+  });
+
+  it("does not retry a request the server called invalid", async () => {
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const middle = Math.floor((T0 - 699 * MIN) / pageMs) * pageMs + pageMs;
+    const { rest, asked } = restStub(bars, {
+      fail: (from) => (from === middle ? new PodHttpError(400, "url", "bad request") : false),
+    });
+    await expect(
+      fetchCandleHistory(rest, ID, "1m", { from: T0 - 699 * MIN, to: T0 + MIN }, T0 + MIN),
+    ).rejects.toThrow(/bad request/);
+    expect(asked.filter((a) => a.from === middle)).toHaveLength(1); // asked once, not retried
+  });
+
+  it("stops at a gap on the old end instead of failing the window", async () => {
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const oldest = Math.floor((T0 - 699 * MIN) / pageMs) * pageMs;
+    const { rest } = restStub(bars, { fail: (from) => from === oldest });
+    const got = await fetchCandleHistory(rest, ID, "1m", { from: T0 - 699 * MIN, to: T0 + MIN }, T0 + MIN);
+    // History simply starts at the next page; the caller re-asks when it pans.
+    expect(got[0]!.time).toBe(oldest + pageMs);
+    expect(got.at(-1)!.time).toBe(T0);
+  });
+
+  it("rejects a gap that would sit between bars it is returning", async () => {
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const middle = Math.floor((T0 - 699 * MIN) / pageMs) * pageMs + pageMs;
+    const { rest } = restStub(bars, { fail: (from) => from === middle });
+    await expect(
+      fetchCandleHistory(rest, ID, "1m", { from: T0 - 699 * MIN, to: T0 + MIN }, T0 + MIN),
+    ).rejects.toThrow(/failed/);
+  });
+});
+
+describe("page cache", () => {
+  it("serves a repeat read of a final page without asking again", async () => {
+    const bars = series1m(700);
+    const { rest, asked } = restStub(bars);
+    const range = { from: bars[0]!.time, to: T0 + MIN };
+    const first = await fetchCandleHistory(rest, ID, "1m", range, T0 + MIN);
+    const asksAfterFirst = asked.length;
+    const second = await fetchCandleHistory(rest, ID, "1m", range, T0 + MIN);
+    expect(second.map((b) => b.time)).toEqual(first.map((b) => b.time));
+    // Only the trailing (still-growing) page is re-asked; the full pages are not.
+    expect(asked.length - asksAfterFirst).toBeLessThan(asksAfterFirst);
+  });
+
+  it("never stores a page the indexer had not caught up to", async () => {
+    const bars = series1m(700);
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    // A page that is whole by the clock, but whose last bars are not indexed yet.
+    const page = Math.floor(bars[0]!.time / pageMs) + 1;
+    const lagging = page * pageMs + 10 * MIN;
+    const { rest, state } = restStub(bars, { solutionNow: lagging });
+    const range = { from: page * pageMs, to: (page + 1) * pageMs };
+    const short = await fetchCandleHistory(rest, ID, "1m", range, T0 + MIN);
+    expect(short.at(-1)!.time).toBeLessThan(lagging); // truncated, as the server would
+
+    // Once the indexer catches up the same window must come back complete —
+    // caching the short answer would have pinned that hole forever.
+    state.solutionNow = Number.MAX_SAFE_INTEGER;
+    const full = await fetchCandleHistory(rest, ID, "1m", range, T0 + MIN);
+    expect(full.length).toBeGreaterThan(short.length);
+    expect(full.at(-1)!.time).toBe(range.to - MIN);
+  });
+});
+
+describe("CandleSeries page cache", () => {
+  const ctxWith = (rest: PodRestClient): SyncContext => ({
+    rest,
+    ws: {
+      subscribe: () => ({ unsubscribe() {}, update() {}, resubscribe() {} }),
+      on: () => () => {},
+    },
+  } as unknown as SyncContext);
+
+  // A failing page burns its retries and backoff before the load settles.
+  const until = (cond: () => boolean) => vi.waitUntil(cond, { timeout: 8000, interval: 10 });
+
+  it("does not cache a failed page, so a later load retries it", async () => {
+    const bars = series1m(400); // spans two 1m pages
+    let failing = true;
+    const pageMs = RESOLUTION_PAGE_BUCKETS["1m"] * MIN;
+    const oldest = Math.floor(bars[0]!.time / pageMs) * pageMs;
+    const { rest, asked } = restStub(bars, { fail: (from) => failing && from === oldest });
+
+    const s = new CandleSeries(ctxWith(rest), ID, "1m", { from: bars[0]!.time, to: T0 + MIN });
+    const off = s.subscribe(() => {});
+    await until(() => asked.some((a) => a.from === oldest));
+    await until(() => !s.loading());
+    // The failed page contributed nothing...
+    expect((s.get() ?? []).some((b) => b.time === bars[0]!.time)).toBe(false);
+
+    // ...and is not remembered as empty: the same window asks for it again.
+    failing = false;
+    const before = asked.filter((a) => a.from === oldest).length;
+    s.setWindow({ from: bars[0]!.time, to: T0 + MIN });
+    await until(() => asked.filter((a) => a.from === oldest).length > before);
+    await until(() => (s.get() ?? []).some((b) => b.time === bars[0]!.time));
+    off();
+  });
+});

--- a/ts-sdk/src/sync/candles.ts
+++ b/ts-sdk/src/sync/candles.ts
@@ -46,6 +46,13 @@ const SEED_RESOLUTION: Resolution = "1h";
  * buckets, identified by its page index. */
 export interface CandlePageWindow { page: number; fromMs: number; toMs: number }
 
+/**
+ * One page's bars, plus how far the indexer had actually got. `watermarkMs` is
+ * `MAX_SAFE_INTEGER` when the page is known complete (a settled cache hit), so
+ * it never bounds a read it has nothing to say about.
+ */
+interface CandlePage { bars: Bar[]; watermarkMs: number }
+
 const pageSpanMs = (resolution: Resolution) =>
   RESOLUTION_PAGE_BUCKETS[resolution] * RESOLUTION_SECONDS[resolution] * 1000;
 
@@ -117,7 +124,10 @@ export function candleTailFrom(
   return new Promise((resolve) => {
     let release: (() => void) | undefined;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
     const settle = (bars: Bar[]) => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
       release?.();
       resolve(bars);
@@ -127,6 +137,10 @@ export function candleTailFrom(
       const bars = inWindow();
       if (bars.length) settle(bars);
     });
+    // `subscribe` starts the source, which can emit synchronously inside the
+    // call above — before `release` was assigned. Release here or the listener
+    // (and with it the series' tick fold) is never let go.
+    if (settled) release();
   });
 }
 
@@ -155,14 +169,14 @@ async function fetchCandlePage(
   id: MarketId,
   resolution: Resolution,
   window: CandlePageWindow,
-): Promise<Bar[]> {
+): Promise<CandlePage> {
   const wholePage = window.toMs - window.fromMs === pageSpanMs(resolution);
   const key = `${id}:${resolution}:${window.page}`;
   let cache = pageCaches.get(rest);
   if (!cache) pageCaches.set(rest, (cache = new Map()));
   // Cached entries were verified final when stored, so a hit needs no re-check.
   const hit = wholePage ? cache.get(key) : undefined;
-  if (hit) return hit;
+  if (hit) return { bars: hit, watermarkMs: Number.MAX_SAFE_INTEGER };
   for (let attempt = 1; ; attempt++) {
     try {
       const page = await rest.candles(id, {
@@ -171,18 +185,22 @@ async function fetchCandlePage(
         to: window.toMs,
         limit: RESOLUTION_PAGE_BUCKETS[resolution],
       });
-      // The indexer's watermark is the server's own test for a final answer: a
-      // window it has not reached yet comes back short of its newest buckets.
-      const final = page.solutionNow >= window.toMs;
-      if (final && wholePage) {
+      // Two different questions, so two predicates. Cacheable? Only a whole
+      // page the indexer has passed can never change again.
+      const covered = page.solutionNow >= window.toMs;
+      if (covered && wholePage) {
         // Oldest insertion out first; the bound is on memory, not a policy.
         if (cache.size >= PAGE_CACHE_MAX) cache.delete(cache.keys().next().value!);
         cache.set(key, page.bars);
       }
-      // Retry a short answer rather than let a caller take it as complete — the
-      // watermark is usually a second behind. On the last attempt return what
-      // there is: a lagging indexer must not turn into a hard failure.
-      if (final || attempt >= PAGE_ATTEMPTS) return page.bars;
+      // Worth retrying? Only a WHOLE page that came back short — the indexer is
+      // behind by more than a page and a moment will fix it. The trailing page
+      // is clamped by OUR clock, so its shortfall is the normal state of
+      // affairs, and retrying it spins three requests and seconds of backoff
+      // against a healthy node on nothing worse than clock skew.
+      if (covered || !wholePage || attempt >= PAGE_ATTEMPTS) {
+        return { bars: page.bars, watermarkMs: page.solutionNow };
+      }
     } catch (err) {
       if (attempt >= PAGE_ATTEMPTS || !worthRetrying(err)) throw err;
     }
@@ -237,7 +255,7 @@ export async function fetchCandleHistory(
 ): Promise<Bar[]> {
   const toMs = range.to ?? nowMs;
   const windows = candlePageWindows(resolution, range.from, toMs, nowMs);
-  const pages: Bar[][] = new Array(windows.length);
+  const pages: CandlePage[] = new Array(windows.length);
   const failures: unknown[] = new Array(windows.length);
   // Newest page first, `HISTORY_CONCURRENCY` at a time: a wide window is tens
   // of pages (56 for a fortnight of 1m bars, thousands for a year), and firing
@@ -263,9 +281,15 @@ export async function fetchCandleHistory(
   for (let i = oldestOk; i < pages.length; i++) {
     if (pages[i] === undefined) throw failures[i]; // a gap with bars on both sides
   }
+  const kept = pages.slice(Math.max(0, oldestOk));
+  // The indexer's watermark bounds what any of these answers could cover:
+  // buckets past it are not history yet, they are simply unwritten. Claiming
+  // only up to there keeps a lagging indexer from looking like a complete
+  // window that happens to stop early.
+  const coveredToMs = kept.reduce((limit, page) => Math.min(limit, page.watermarkMs), toMs);
   // Pages tile the window in ascending order and never overlap, so this is
   // already sorted; the filter drops the partial buckets at either edge.
-  return pages.slice(Math.max(0, oldestOk)).flat().filter((b) => b.time >= range.from && b.time < toMs);
+  return kept.flatMap((page) => page.bars).filter((b) => b.time >= range.from && b.time < coveredToMs);
 }
 
 export class CandleSeries implements SeriesResource<Bar> {
@@ -327,6 +351,12 @@ export class CandleSeries implements SeriesResource<Bar> {
         this.tickSub?.unsubscribe();
         this.tickSub = undefined;
         this.handle = undefined;
+        // Folded buckets do not survive the fold being stopped: on re-subscribe
+        // the first `rebuild()` would re-emit a partially-folded bucket from
+        // whenever the series last ran, and a reader asking for the forming
+        // edge would take it as the answer. Closed pages are immutable, so they
+        // stay — dropping them would only refetch what is already correct.
+        this.live.clear();
       };
     });
   }
@@ -382,7 +412,7 @@ export class CandleSeries implements SeriesResource<Bar> {
         const window = candlePageWindow(this.resolution, p, nowMs);
         if (!window) { this.notePage(p); return; }
         try {
-          const bars = await fetchCandlePage(this.ctx.rest, this.id, this.resolution, window);
+          const { bars } = await fetchCandlePage(this.ctx.rest, this.id, this.resolution, window);
           this.pages.set(p, bars);
           this.notePage(p);
           if (bars.length === 0 && this.minPage === p) this._hasMore = false;

--- a/ts-sdk/src/sync/candles.ts
+++ b/ts-sdk/src/sync/candles.ts
@@ -17,11 +17,13 @@ import { dec, usToMs, WAD } from "../codec/units.js";
 import { RESOLUTION_PAGE_BUCKETS, RESOLUTION_SECONDS } from "../codec/resolution.js";
 import { BaseResource, type ResourceHandle } from "../stores/resource.js";
 import type { Subscription } from "../transport/ws.js";
+import { PodHttpError, type PodRestClient } from "../transport/rest.js";
 import type { SyncContext } from "./sources.js";
 
 export interface SeriesResource<Item> {
   get(): Item[] | undefined;
   subscribe(listener: () => void): () => void;
+  /** First committed value, not "window loaded" — see `Resource.ready`. */
   ready(): Promise<Item[]>;
   readonly error?: Error;
   setWindow(range: TimeRange): void;
@@ -40,6 +42,191 @@ const bmin = (a: bigint, b: bigint) => (a < b ? a : b);
 const REPLAY_SAFE_SECS = 3_600;
 const SEED_RESOLUTION: Resolution = "1h";
 
+/** One canonical page window: an epoch-anchored span of `RESOLUTION_PAGE_BUCKETS`
+ * buckets, identified by its page index. */
+export interface CandlePageWindow { page: number; fromMs: number; toMs: number }
+
+const pageSpanMs = (resolution: Resolution) =>
+  RESOLUTION_PAGE_BUCKETS[resolution] * RESOLUTION_SECONDS[resolution] * 1000;
+
+/**
+ * Page index of `ms` on a resolution's epoch-anchored grid — the single
+ * definition of that grid. Every candle read goes through it on purpose: the
+ * server's `immutable` responses and the REST client's URL-keyed in-flight
+ * dedupe both only pay off while every request lands on the same boundaries, so
+ * a second implementation of this arithmetic would silently turn cache hits
+ * into node traffic.
+ */
+export function candlePageAt(resolution: Resolution, ms: number): number {
+  return Math.floor(Math.max(0, ms) / pageSpanMs(resolution));
+}
+
+/**
+ * One page's canonical window — `undefined` when the page holds nothing but the
+ * forming bucket, because there is nothing closed to fetch. The window is
+ * clamped to the last closed bucket so it stays fully elapsed: those are the
+ * responses the server marks `immutable`, while a `to` in the future is
+ * `no-store` on every open.
+ */
+export function candlePageWindow(
+  resolution: Resolution,
+  page: number,
+  nowMs = Date.now(),
+): CandlePageWindow | undefined {
+  const stepMs = RESOLUTION_SECONDS[resolution] * 1000;
+  const fromMs = page * pageSpanMs(resolution);
+  const toMs = Math.min(fromMs + pageSpanMs(resolution), Math.floor(nowMs / stepMs) * stepMs);
+  return toMs > fromMs ? { page, fromMs, toMs } : undefined;
+}
+
+/** The canonical windows covering `[fromMs, toMs)`, oldest first. */
+export function candlePageWindows(
+  resolution: Resolution,
+  fromMs: number,
+  toMs: number,
+  nowMs = Date.now(),
+): CandlePageWindow[] {
+  const windows: CandlePageWindow[] = [];
+  const last = candlePageAt(resolution, toMs - 1);
+  for (let page = candlePageAt(resolution, fromMs); page <= last; page++) {
+    const window = candlePageWindow(resolution, page, nowMs);
+    if (window) windows.push(window);
+  }
+  return windows;
+}
+
+/**
+ * Decoded pages, per REST client — so per host, never shared between clients
+ * pointed at different environments. A page is only stored once it can never
+ * change again, which takes BOTH of: a full span (not the trailing page, which
+ * still grows as buckets close) and an indexer watermark past the window's end.
+ * Wall clock is not enough — the server gates its own `immutable` header on
+ * solution time, and a window that has elapsed by the clock while the indexer
+ * lags comes back SHORT of its newest buckets. Caching that would pin a hole
+ * for the process's lifetime, which is the failure this whole read exists to
+ * avoid.
+ *
+ * Without this, overlapping requests re-decode the same bars, and overlap is
+ * the norm: a chart's opening window reaches further back than it has been
+ * served, and every pan-left ends mid-page. Decoding costs six `BigInt` parses
+ * per bar (see `decodeCandle`) on the thread that draws the chart.
+ */
+const pageCaches = new WeakMap<PodRestClient, Map<string, Bar[]>>();
+const PAGE_CACHE_MAX = 256;
+
+/** One canonical page, served from this client's page cache when it is final. */
+async function fetchCandlePage(
+  rest: PodRestClient,
+  id: MarketId,
+  resolution: Resolution,
+  window: CandlePageWindow,
+): Promise<Bar[]> {
+  const wholePage = window.toMs - window.fromMs === pageSpanMs(resolution);
+  const key = `${id}:${resolution}:${window.page}`;
+  let cache = pageCaches.get(rest);
+  if (!cache) pageCaches.set(rest, (cache = new Map()));
+  // Cached entries were verified final when stored, so a hit needs no re-check.
+  const hit = wholePage ? cache.get(key) : undefined;
+  if (hit) return hit;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const page = await rest.candles(id, {
+        resolution,
+        from: window.fromMs,
+        to: window.toMs,
+        limit: RESOLUTION_PAGE_BUCKETS[resolution],
+      });
+      if (wholePage && page.solutionNow >= window.toMs) {
+        // Oldest insertion out first; the bound is on memory, not a policy.
+        if (cache.size >= PAGE_CACHE_MAX) cache.delete(cache.keys().next().value!);
+        cache.set(key, page.bars);
+      }
+      return page.bars;
+    } catch (err) {
+      if (attempt >= PAGE_ATTEMPTS || !worthRetrying(err)) throw err;
+      // Exponential with jitter: the node sheds load in bursts, and a read that
+      // retries on a fixed short delay just lands inside the same burst.
+      const backoff = PAGE_RETRY_MS * 2 ** (attempt - 1) * (1 + Math.random());
+      await new Promise((resolve) => setTimeout(resolve, backoff));
+    }
+  }
+}
+
+/** How many pages a history read has in flight at once. */
+const HISTORY_CONCURRENCY = 8;
+
+/**
+ * Attempts per page, and the backoff between them. One failure must not decide
+ * a whole read: `fetchCandleHistory` rejects the window on a failed page, and a
+ * chart shows that as a hard error it will not retry on its own. Cold windows
+ * on a busy node do fail once and then answer in half a second, which is
+ * exactly what a retry is for. A 4xx (other than 429) is the server saying the
+ * request itself is wrong — asking again cannot help.
+ */
+const PAGE_ATTEMPTS = 3;
+const PAGE_RETRY_MS = 400;
+
+const worthRetrying = (err: unknown) =>
+  !(err instanceof PodHttpError) || err.status === 429 || err.status >= 500;
+
+/**
+ * Closed bars covering `[range.from, range.to)` — the one-shot read behind a
+ * chart's history request, with no resource, no subscription and no shared
+ * mutable state.
+ *
+ * A page that fails after its retries decides how much of the window is
+ * deliverable, and WHERE it failed is what matters:
+ *
+ * - at the old end, the answer is simply shorter — history stops at the gap,
+ *   and the caller asks again for the older range when it needs it (a chart
+ *   does exactly that on the next pan). Nothing is misrepresented.
+ * - anywhere inside, the read REJECTS. A chart treats the answer as the truth
+ *   for the range it asked about and does not re-ask, so bars either side of a
+ *   swallowed gap would draw a hole nobody can detect — the failure this whole
+ *   read exists to prevent. Callers get an error they can retry.
+ *
+ * (The live series takes the opposite side of that trade — see `fetchPages`.)
+ */
+export async function fetchCandleHistory(
+  rest: PodRestClient,
+  id: MarketId,
+  resolution: Resolution,
+  range: TimeRange,
+  nowMs = Date.now(),
+): Promise<Bar[]> {
+  const toMs = range.to ?? nowMs;
+  const windows = candlePageWindows(resolution, range.from, toMs, nowMs);
+  const pages: Bar[][] = new Array(windows.length);
+  const failures: unknown[] = new Array(windows.length);
+  // Newest page first, `HISTORY_CONCURRENCY` at a time: a wide window is tens
+  // of pages (56 for a fortnight of 1m bars, thousands for a year), and firing
+  // them all at once queues the visible edge behind the oldest history on
+  // HTTP/1.1 and lands the whole fan-out on the node at once on HTTP/2.
+  let next = windows.length - 1;
+  const worker = async () => {
+    while (next >= 0) {
+      const i = next--;
+      try {
+        pages[i] = await fetchCandlePage(rest, id, resolution, windows[i]!);
+      } catch (err) {
+        failures[i] = err;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(HISTORY_CONCURRENCY, windows.length) }, worker));
+
+  // An unfetched page reads as `undefined`; an empty page is an empty array, so
+  // "no bars here" and "never arrived" stay distinguishable.
+  const oldestOk = pages.findIndex((page) => page !== undefined);
+  if (windows.length && oldestOk === -1) throw failures.find((err) => err !== undefined);
+  for (let i = oldestOk; i < pages.length; i++) {
+    if (pages[i] === undefined) throw failures[i]; // a gap with bars on both sides
+  }
+  // Pages tile the window in ascending order and never overlap, so this is
+  // already sorted; the filter drops the partial buckets at either edge.
+  return pages.slice(Math.max(0, oldestOk)).flat().filter((b) => b.time >= range.from && b.time < toMs);
+}
+
 export class CandleSeries implements SeriesResource<Bar> {
   private readonly base: BaseResource<Bar[]>;
   private handle: ResourceHandle<Bar[]> | undefined;
@@ -47,12 +234,9 @@ export class CandleSeries implements SeriesResource<Bar> {
   private readonly pages = new Map<number, Bar[]>(); // pageIndex -> closed bars
   private readonly live = new Map<number, Bar>(); // bucketStartMs -> forming bar
   private readonly resSecs: number;
-  private readonly pageBuckets: number;
-  private readonly pageSpanSecs: number;
 
   private window: TimeRange;
   private minPage: number | undefined;
-  private maxPage: number | undefined;
   private _loading = false;
   private _hasMore = true;
   private lastTickUs = 0;
@@ -68,10 +252,7 @@ export class CandleSeries implements SeriesResource<Bar> {
     range?: TimeRange,
   ) {
     this.resSecs = RESOLUTION_SECONDS[resolution];
-    this.pageBuckets = RESOLUTION_PAGE_BUCKETS[resolution];
-    this.pageSpanSecs = this.resSecs * this.pageBuckets;
-    const span = this.pageSpanSecs * 1000;
-    this.window = range ?? { from: Date.now() - span };
+    this.window = range ?? { from: Date.now() - pageSpanMs(resolution) };
 
     this.base = new BaseResource<Bar[]>((h) => {
       this.handle = h;
@@ -131,17 +312,12 @@ export class CandleSeries implements SeriesResource<Bar> {
 
   // --- internals ---
 
-  private pageOf(secs: number): number {
-    return Math.floor(secs / this.pageSpanSecs);
-  }
-
   private async loadWindow(range: TimeRange): Promise<void> {
-    const fromSecs = Math.floor(range.from / 1000);
-    const toSecs = Math.floor((range.to ?? Date.now()) / 1000);
-    const startPage = this.pageOf(fromSecs);
-    const endPage = this.pageOf(Math.max(fromSecs, toSecs - 1));
-    const nowSecs = Math.floor(Date.now() / 1000);
-    const trailingPage = this.pageOf(nowSecs);
+    const nowMs = Date.now();
+    const toMs = range.to ?? nowMs;
+    const startPage = candlePageAt(this.resolution, range.from);
+    const endPage = candlePageAt(this.resolution, Math.max(range.from, toMs - 1));
+    const trailingPage = candlePageAt(this.resolution, nowMs);
 
     const wanted: number[] = [];
     for (let p = startPage; p <= endPage; p++) {
@@ -150,42 +326,32 @@ export class CandleSeries implements SeriesResource<Bar> {
     await this.fetchPages(wanted);
   }
 
+  /** The oldest page loaded — `loadOlder` walks down from it. */
+  private notePage(page: number): void {
+    this.minPage = Math.min(this.minPage ?? page, page);
+  }
+
   private async fetchPages(pageIndices: number[]): Promise<void> {
     if (!pageIndices.length) { this.rebuild(); return; }
     this._loading = true;
     this.rebuild(); // surface loading state
     try {
-      // The trailing page's window is clamped to the last closed bucket: the
-      // server returns only closed bars either way, so the content is
-      // identical — but a fully-elapsed window is served `immutable`
-      // (browser/CDN-cacheable; its URL rotates once per bucket close), while
-      // a `to` in the future would be `no-store` on every open. The forming
-      // bucket comes from the tick subscription (see prepareLiveEdge).
-      const lastClosedMs = Math.floor(Date.now() / 1000 / this.resSecs) * this.resSecs * 1000;
+      const nowMs = Date.now(); // one clock read, so every page agrees on it
       await Promise.all(pageIndices.map(async (p) => {
-        const fromMs = p * this.pageSpanSecs * 1000;
-        const toMs = Math.min((p + 1) * this.pageSpanSecs * 1000, lastClosedMs);
-        if (toMs <= fromMs) {
-          // Page holds nothing but the forming bucket (it just started) —
-          // nothing closed to fetch yet; keep bookkeeping consistent.
-          this.pages.set(p, this.pages.get(p) ?? []);
-          this.minPage = this.minPage === undefined ? p : Math.min(this.minPage, p);
-          this.maxPage = this.maxPage === undefined ? p : Math.max(this.maxPage, p);
-          return;
-        }
+        const window = candlePageWindow(this.resolution, p, nowMs);
+        if (!window) { this.notePage(p); return; }
         try {
-          const page = await this.ctx.rest.candles(this.id, {
-            resolution: this.resolution,
-            from: fromMs,
-            to: toMs,
-            limit: this.pageBuckets,
-          });
-          this.pages.set(p, page.bars);
-          this.minPage = this.minPage === undefined ? p : Math.min(this.minPage, p);
-          this.maxPage = this.maxPage === undefined ? p : Math.max(this.maxPage, p);
-          if (page.bars.length === 0 && this.minPage === p) this._hasMore = false;
+          const bars = await fetchCandlePage(this.ctx.rest, this.id, this.resolution, window);
+          this.pages.set(p, bars);
+          this.notePage(p);
+          if (bars.length === 0 && this.minPage === p) this._hasMore = false;
         } catch {
-          this.pages.set(p, this.pages.get(p) ?? []);
+          // A live series tolerates a missing page where `fetchCandleHistory`
+          // rejects: it will ask again. But leave the page MISSING rather than
+          // storing it empty — a stored empty page is indistinguishable from
+          // "no bars in this span", so a transient failure would become a
+          // permanent hole, since `loadWindow` only fetches pages it does not
+          // already have.
         }
       }));
     } finally {

--- a/ts-sdk/src/sync/candles.ts
+++ b/ts-sdk/src/sync/candles.ts
@@ -238,7 +238,9 @@ const worthRetrying = (err: unknown) =>
  *
  * - at the old end, the answer is simply shorter — history stops at the gap,
  *   and the caller asks again for the older range when it needs it (a chart
- *   does exactly that on the next pan). Nothing is misrepresented.
+ *   does exactly that on the next pan). Nothing is misrepresented, with one
+ *   exception that must not slip through: if nothing at all survives, an empty
+ *   answer would assert the window is empty, so that case rejects too.
  * - anywhere inside, the read REJECTS. A chart treats the answer as the truth
  *   for the range it asked about and does not re-ask, so bars either side of a
  *   swallowed gap would draw a hole nobody can detect — the failure this whole
@@ -289,7 +291,20 @@ export async function fetchCandleHistory(
   const coveredToMs = kept.reduce((limit, page) => Math.min(limit, page.watermarkMs), toMs);
   // Pages tile the window in ascending order and never overlap, so this is
   // already sorted; the filter drops the partial buckets at either edge.
-  return kept.flatMap((page) => page.bars).filter((b) => b.time >= range.from && b.time < coveredToMs);
+  const bars = kept.flatMap((page) => page.bars).filter((b) => b.time >= range.from && b.time < coveredToMs);
+
+  // An EMPTY answer is not a small answer: it asserts "there are no bars in this
+  // window", and a chart takes that as settled and stops asking. Only the part
+  // of the window that was actually read can say that. So when nothing came
+  // back and the window was not covered — a failed page dropped off the old
+  // end, or the watermark short of the new end — surface the failure instead,
+  // which the caller retries. Otherwise a quiet stretch next to a shed page
+  // would hide that page's bars for as long as the chart lives.
+  if (!bars.length && (oldestOk > 0 || coveredToMs < toMs)) {
+    throw failures[oldestOk - 1]
+      ?? new Error(`candle history for ${id} is not indexed past ${coveredToMs}`);
+  }
+  return bars;
 }
 
 export class CandleSeries implements SeriesResource<Bar> {

--- a/ts-sdk/src/sync/candles.ts
+++ b/ts-sdk/src/sync/candles.ts
@@ -96,6 +96,41 @@ export function candlePageWindows(
 }
 
 /**
+ * The live series' bars inside `range`, waiting up to `timeoutMs` for one to
+ * turn up. The series folds the tick stream, so this is where the forming
+ * bucket comes from — REST withholds it.
+ *
+ * Deliberately not `ready()`: that resolves on the series' FIRST commit, and a
+ * fresh series commits an empty seed while its load is still in flight (see
+ * `fetchPages`, which surfaces loading state before any page lands). Awaiting
+ * it hands back `[]` and gives up before the bucket it was called for arrives.
+ */
+export function candleTailFrom(
+  series: SeriesResource<Bar>,
+  range: TimeRange,
+  timeoutMs: number,
+): Promise<Bar[]> {
+  const toMs = range.to ?? Number.MAX_SAFE_INTEGER;
+  const inWindow = () => (series.get() ?? []).filter((b) => b.time >= range.from && b.time < toMs);
+  const found = inWindow();
+  if (found.length) return Promise.resolve(found);
+  return new Promise((resolve) => {
+    let release: (() => void) | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const settle = (bars: Bar[]) => {
+      clearTimeout(timer);
+      release?.();
+      resolve(bars);
+    };
+    timer = setTimeout(() => settle(inWindow()), timeoutMs);
+    release = series.subscribe(() => {
+      const bars = inWindow();
+      if (bars.length) settle(bars);
+    });
+  });
+}
+
+/**
  * Decoded pages, per REST client — so per host, never shared between clients
  * pointed at different environments. A page is only stored once it can never
  * change again, which takes BOTH of: a full span (not the trailing page, which
@@ -136,19 +171,25 @@ async function fetchCandlePage(
         to: window.toMs,
         limit: RESOLUTION_PAGE_BUCKETS[resolution],
       });
-      if (wholePage && page.solutionNow >= window.toMs) {
+      // The indexer's watermark is the server's own test for a final answer: a
+      // window it has not reached yet comes back short of its newest buckets.
+      const final = page.solutionNow >= window.toMs;
+      if (final && wholePage) {
         // Oldest insertion out first; the bound is on memory, not a policy.
         if (cache.size >= PAGE_CACHE_MAX) cache.delete(cache.keys().next().value!);
         cache.set(key, page.bars);
       }
-      return page.bars;
+      // Retry a short answer rather than let a caller take it as complete — the
+      // watermark is usually a second behind. On the last attempt return what
+      // there is: a lagging indexer must not turn into a hard failure.
+      if (final || attempt >= PAGE_ATTEMPTS) return page.bars;
     } catch (err) {
       if (attempt >= PAGE_ATTEMPTS || !worthRetrying(err)) throw err;
-      // Exponential with jitter: the node sheds load in bursts, and a read that
-      // retries on a fixed short delay just lands inside the same burst.
-      const backoff = PAGE_RETRY_MS * 2 ** (attempt - 1) * (1 + Math.random());
-      await new Promise((resolve) => setTimeout(resolve, backoff));
     }
+    // Exponential with jitter: the node sheds load in bursts, and a read that
+    // retries on a fixed short delay just lands inside the same burst.
+    const backoff = PAGE_RETRY_MS * 2 ** (attempt - 1) * (1 + Math.random());
+    await new Promise((resolve) => setTimeout(resolve, backoff));
   }
 }
 

--- a/ts-sdk/src/transport/rest.test.ts
+++ b/ts-sdk/src/transport/rest.test.ts
@@ -1,0 +1,34 @@
+// A REST read that never settles is worse than one that fails: it holds its
+// slot in `inflight`, so every retry of that URL joins the hang instead of
+// trying again. Cold candle windows on a busy node have hung for tens of
+// seconds and then answered in half a second.
+
+import { describe, expect, it } from "vitest";
+
+import { PodRestClient } from "./rest.js";
+
+describe("PodRestClient request timeout", () => {
+  const clientWith = (fetchFn: unknown, timeoutMs?: number) =>
+    new PodRestClient({ restUrl: "http://node.test/v1", timeoutMs, fetch: fetchFn as typeof fetch });
+
+  it("passes an abort signal with every request", async () => {
+    let seen: AbortSignal | undefined;
+    const rest = clientWith((_url: string, init?: RequestInit) => {
+      seen = init?.signal ?? undefined;
+      return Promise.resolve(new Response(JSON.stringify({ solution_now: 1 }), { status: 200 }));
+    });
+    await rest.status();
+    expect(seen).toBeInstanceOf(AbortSignal);
+  });
+
+  it("fails a request that never settles, rather than hanging", async () => {
+    const rest = clientWith(
+      (_url: string, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+      20,
+    );
+    await expect(rest.status()).rejects.toThrow();
+  });
+});

--- a/ts-sdk/src/transport/rest.ts
+++ b/ts-sdk/src/transport/rest.ts
@@ -70,16 +70,25 @@ type FetchFn = typeof fetch;
 export interface RestClientOptions {
   restUrl: string;
   fetch?: FetchFn;
+  /**
+   * Per-request timeout (ms, default 15s). A request that never settles is
+   * worse than one that fails: it holds its slot in `inflight`, so retries of
+   * the same URL join the hang instead of trying again. Cold candle windows on
+   * a busy node have taken tens of seconds and then answered in half a second.
+   */
+  timeoutMs?: number;
 }
 
 export class PodRestClient {
   private readonly base: string;
   private readonly fetchFn: FetchFn;
+  private readonly timeoutMs: number;
   private readonly inflight = new Map<string, Promise<unknown>>();
 
   constructor(opts: RestClientOptions) {
     this.base = opts.restUrl.replace(/\/$/, "");
     this.fetchFn = opts.fetch ?? globalThis.fetch.bind(globalThis);
+    this.timeoutMs = opts.timeoutMs ?? 15_000;
   }
 
   private async get<T>(path: string, query?: Record<string, string | number | undefined>): Promise<T> {
@@ -105,7 +114,12 @@ export class PodRestClient {
   }
 
   private async doGet<T>(url: string): Promise<T> {
-    const res = await this.fetchFn(url, { headers: { accept: "application/json" } });
+    const res = await this.fetchFn(url, {
+      headers: { accept: "application/json" },
+      // `AbortSignal.timeout` everywhere current; omitted rather than polyfilled
+      // where it is missing, which only loses the timeout.
+      signal: AbortSignal.timeout?.(this.timeoutMs),
+    });
     if (!res.ok) {
       let body = "";
       try { body = await res.text(); } catch { /* ignore */ }


### PR DESCRIPTION
Chart history went through the `CandleSeries` that `client.candles` memoises per (market, resolution) and shares with the live subscription, so a history read waited on a single shared `loading()` flag: an unrelated load finishing resolved it, and it answered "no bars" for a window whose own pages were still in flight. The bars arrived — HTTP 200 — and the chart drew a hole where they belonged. A page whose fetch failed was then stored as an empty page, which is indistinguishable from "no bars in this span", so the hole was permanent: `loadWindow` only fetches pages it does not already have, and nothing ever retried it.

Found while chasing a staging chart that showed two weeks of flat lines and a time axis jumping from Aug 7 to Aug 19 with all the data present server-side.

## What changed

`client.candleHistory(id, resolution, range)` is the read chart history should use: it owns its request, and resolves with the whole window or rejects. `client.candleTail(id, resolution, range)` is the other half — the forming bucket REST withholds — so a market whose only activity is in the open bucket gets that bar instead of `noData`, which a chart latches onto. `createPodDatafeed` had the original bug and now uses both.

The page grid (`candlePageAt` / `candlePageWindow`) is a single definition again and the page fetch a single function, so every read keeps landing on the boundaries the server marks `immutable` and the REST client's URL-keyed in-flight dedupe keeps paying off.

Decoded pages are cached per REST client — never shared across hosts — and stored only once the response's `solutionNow` watermark has passed the window's end. Wall clock is not enough: the server gates its own `immutable` header on solution time, so a window that has elapsed by the clock while the indexer lags comes back short of its newest buckets, and caching that pins a hole for the process's lifetime.

Pages are fetched newest-first, eight at a time, each retried with jittered exponential backoff, under a new per-request timeout (`RestClientOptions.timeoutMs`, default 15s). A request that never settles is worse than one that fails: it holds its slot in `inflight`, so retries of that URL join the hang instead of trying again. Staging demonstrated both failure modes — a cold candle window that hung for 45s and then answered in 0.55s, and intermittent 503s on cold windows.

Where a page finally fails now decides the answer. At the old end, history simply stops there and the caller re-asks when it pans. Anywhere inside the window it still rejects, because bars either side of a swallowed gap would draw a hole nobody can detect — the failure this read exists to prevent.

`Resource.ready()` and `BaseResource.destroy()` grew the contracts that caused this: `ready()` resolves on the first commit, not "loaded", and `destroy()` ignores the subscriber count, so one consumer calling it stops a shared resource under every other holder.

## Review round (fad0f9c)

`candleTail` awaited `series.ready()`, which resolves on the series' FIRST commit — and a fresh series commits an empty seed while its load is still in flight, since `fetchPages` surfaces loading state before any page lands. The wait therefore returned `[]` at once and the forming bucket it exists to fetch never arrived: the `ready()` trap this branch documents, walked into one file over. `candleTailFrom` waits for a bar inside the window, or the timeout, and releases the series either way.

A response whose `solutionNow` is behind the window's end is short of its newest buckets — the server's own test for a final answer. That gated caching, but the short page was still returned, so a caller could take it as complete. It is now retried like any other failure and returned as-is only on the last attempt, because a lagging indexer (minutes behind after a restart) must not turn into a hard error.

The forming-bucket fallback compared `range.to` against `Date.now()`. TradingView rounds `to` to whole seconds, so a window covering the open bucket can end a few hundred ms in the past; it now compares against the current bucket's start. podnetwork/frontend#17 carries the same change for the app's datafeed.

Monthly pages were flagged as needing calendar-month arithmetic. Not taken: the indexer buckets `OneMonth` at a nominal 2592000s, epoch-anchored, and its SQL fold uses the same width (`node/src/clob_indexer/mod.rs`), so fixed-span pages land exactly on the server's buckets while calendar months would diverge from them and lose the `immutable` alignment the page grid exists for. `RESOLUTION_SECONDS`' comment claimed otherwise and is corrected instead.

Tests for the first two: a bar pushed after the call is still returned, the timeout path returns empty without leaving a listener behind, out-of-window bars are ignored, and a window the indexer had not reached is re-asked rather than answered short.

## Second review round (d13e6d5)

`final` was answering two questions with one predicate. For cacheability, "has the indexer passed this window's end?" is exactly right. For the retry decision it is not: `window.toMs` comes from our clock and `solutionNow` from the server's, and the trailing page is clamped by that clock — so its shortfall is the normal state of affairs. A client 30s fast on 1m failed the test for half of every minute and burned three requests plus seconds of backoff against a healthy node, on every `setWindow` and every WS reconnect. Only a whole page that comes back short is retried now.

A short page was then returned indistinguishably from a complete one, since the gap check only looks for array holes — so the shortfall vanished before any caller saw it and a chart took a truncated window as the whole of it. Pages now carry the watermark they were answered at, and a read claims only up to the lowest one: buckets past it are not history yet but unwritten, and the tick stream carries that edge.

`candleTailFrom` assigned `release` after `subscribe()` returned, but `subscribe` starts the source and its first `rebuild()` runs before the first await — so the listener could fire while still being registered, settle with `release` undefined, and leave itself and the series' tick fold running for the process lifetime.

A stopped series kept its folded buckets, so re-subscribing re-emitted a partially-folded bucket from whenever it last ran, and a reader asking for the forming edge took it as the answer. Teardown clears them; closed pages stay, being immutable.

`RESOLUTION_PAGE_BUCKETS`' 1M comment still asserted the calendar-month model this branch rejects.

Each of the first three has a test that fails without the fix. Not changed: `candleTail`'s 1.5s default, which may be tight for 4h/1d/1W/1M where the forming bar waits on a 365-bucket seed — that wants measuring against a real node first.

## Third review round (e8244cb)

Dropping a failed page off the old end is fine while something survives — history starts later and the caller re-asks on the next pan, which is what turned a shed cold page on staging from a chart stuck three days back into a chart showing ten days. It is not fine when nothing survives: an empty answer does not say "less than you asked for", it says "this window has no bars", which a chart settles on and stops asking about. A quiet stretch next to a shed page would then hide that page's bars for as long as the chart lives.

An empty result is now only returned for a window that was actually covered. A dropped prefix, or a watermark short of the new end, surfaces the underlying failure instead — the same rule on both ends.

## Release

No version bump here. Publishing `0.4.1` (tag `ts-sdk-v0.4.1`) is what lets podnetwork/frontend#17 drop its pin at `^0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



