### PR TITLE
build(ts-sdk): release 0.4.1

### DIFF
--- a/ts-sdk/package-lock.json
+++ b/ts-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pod-network/trade-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pod-network/trade-sdk",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "viem": "^2.21.0"

--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-network/trade-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Read/stream TypeScript SDK for the pod trading indexer: cacheable REST seeds + one multiplexed WebSocket, kept in memory. Framework-agnostic.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Version bump only — the code shipped in #277.

0.4.1 publishes `client.candleHistory` and `client.candleTail`, the one-shot candle reads that replace loading chart history through the memoised `CandleSeries`. podnetwork/frontend#17 calls both and cannot run until they are on npm: the published 0.4.0 tarball has neither, and because `vite build` does not typecheck, that repo's checks pass while its preview chart breaks at runtime.

Publishing happens on the tag, not on this merge — `ts-sdk-v0.4.1` triggers `publish-ts-sdk.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
