### PR TITLE
fix: report no block instead of a fabricated one on receipts and logs

### DIFF
--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -1182,8 +1182,8 @@ paths:
                   logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                   transactionHash: "0x63dfbb7b3294d3d9aedb9bd1a306ec40156d0da1c374b2348f60c57186704fcd"
                   transactionIndex: "0x0"
-                  blockHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
-                  blockNumber: "0x1"
+                  blockHash: "0x9f2e1c0a4b7d6835f1a0c9d8e7b6a5948372615f0e9d8c7b6a594837261504f3"
+                  blockNumber: "0x1a4"
                   gasUsed: "0xf4240"
                   effectiveGasPrice: "0x1"
                   from: "0xe51e549231219c35040efcf784f58776d5065d26"
@@ -3005,12 +3005,20 @@ components:
           $ref: '#/components/schemas/Bytes32'
         transactionIndex:
           type: string
-          description: Transaction index in block (hex-encoded)
+          nullable: true
+          description: Transaction index in block (hex-encoded); null when the transaction is in no block
         blockHash:
-          $ref: '#/components/schemas/Bytes32'
+          nullable: true
+          description: Hash of the block the transaction was sequenced in; null when it is in no block
+          allOf:
+            - $ref: '#/components/schemas/Bytes32'
         blockNumber:
           type: string
-          description: Block number (hex-encoded)
+          nullable: true
+          description: |
+            Block number (hex-encoded), or null when the transaction is in no block - `submitSolutions`,
+            recovery transactions, and an orderbook intent whose auction tick has not executed yet. A null
+            block is not a pending state: the receipt is final either way.
         gasUsed:
           $ref: '#/components/schemas/HexUint256'
         effectiveGasPrice:

--- a/doc/api-reference/json-rpc/openapi.yaml
+++ b/doc/api-reference/json-rpc/openapi.yaml
@@ -1181,7 +1181,7 @@ paths:
                   logs: []
                   logsBloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
                   transactionHash: "0x63dfbb7b3294d3d9aedb9bd1a306ec40156d0da1c374b2348f60c57186704fcd"
-                  transactionIndex: "0x0"
+                  transactionIndex: null
                   blockHash: "0x9f2e1c0a4b7d6835f1a0c9d8e7b6a5948372615f0e9d8c7b6a594837261504f3"
                   blockNumber: "0x1a4"
                   gasUsed: "0xf4240"
@@ -3006,7 +3006,9 @@ components:
         transactionIndex:
           type: string
           nullable: true
-          description: Transaction index in block (hex-encoded); null when the transaction is in no block
+          description: |
+            Always null. pod does not order the transactions within a block, so a transaction has no
+            position to report. A log is identified by `transactionHash` and `logIndex` instead.
         blockHash:
           nullable: true
           description: Hash of the block the transaction was sequenced in; null when it is in no block

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -393,6 +393,7 @@ export interface TxExplorer {
   /** Null when the tx is in no block (solutions, recovery, an intent whose
    * auction tick has not run yet); a height once it is sequenced. */
   blockNumber?: string | null;
+  /** Always null: pod does not order the transactions within a block. */
   transactionIndex?: string | null;
   contractAddress?: string | null;
   [k: string]: unknown;

--- a/ts-sdk/src/types/public.ts
+++ b/ts-sdk/src/types/public.ts
@@ -390,8 +390,10 @@ export interface TxExplorer {
   chainId?: string;
   maxFeePerGas?: string;
   effectiveGasPrice?: string;
-  blockNumber?: string;
-  transactionIndex?: string;
+  /** Null when the tx is in no block (solutions, recovery, an intent whose
+   * auction tick has not run yet); a height once it is sequenced. */
+  blockNumber?: string | null;
+  transactionIndex?: string | null;
   contractAddress?: string | null;
   [k: string]: unknown;
 }

--- a/ts-sdk/src/write/index.test.ts
+++ b/ts-sdk/src/write/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { waitForReceipt } from "./index.js";
+import type { Hash } from "../types/public.js";
+
+const TX = `0x${"ab".repeat(32)}` as Hash;
+
+/** Serves one `eth_getTransactionReceipt` result, then repeats it. */
+function fakeReceipt(result: unknown) {
+  return vi.fn(async () => ({ json: async () => ({ jsonrpc: "2.0", id: 1, result }) })) as unknown as typeof fetch;
+}
+
+const base = { status: "0x1", transactionHash: TX, gasUsed: "0xf4240" };
+
+describe("waitForReceipt", () => {
+  it("returns a receipt with no block rather than throwing", async () => {
+    const fetchFn = fakeReceipt({ ...base, blockNumber: null, blockHash: null, transactionIndex: null });
+    await expect(waitForReceipt("http://rpc", TX, { fetch: fetchFn, timeoutMs: 50 })).resolves.toEqual({
+      status: "success",
+      transactionHash: TX,
+      blockNumber: null,
+      gasUsed: 1_000_000n,
+    });
+  });
+
+  it("reports the height for a sequenced tx", async () => {
+    const fetchFn = fakeReceipt({ ...base, blockNumber: "0x1a4" });
+    const r = await waitForReceipt("http://rpc", TX, { fetch: fetchFn, timeoutMs: 50 });
+    expect(r.blockNumber).toBe(420n);
+  });
+
+  it("keeps polling while the node has no receipt", async () => {
+    const fetchFn = fakeReceipt(null);
+    await expect(waitForReceipt("http://rpc", TX, { fetch: fetchFn, timeoutMs: 10, pollMs: 1 })).rejects.toThrow(
+      /timed out/,
+    );
+  });
+});

--- a/ts-sdk/src/write/index.ts
+++ b/ts-sdk/src/write/index.ts
@@ -507,18 +507,21 @@ export function buildClosePosition(p: ClosePositionParams): PodTxRequest {
   });
 }
 
-/** A mined transaction receipt (the fields a consumer typically needs). */
+/** A transaction receipt (the fields a consumer typically needs). */
 export interface TxReceipt {
   /** `success` when the tx executed (status `0x1`); `reverted` on `0x0`. */
   status: "success" | "reverted";
   transactionHash: Hash;
-  blockNumber: bigint;
+  /** The height the tx was sequenced at, or `null` when it is in no block —
+   * `submitSolutions`, recovery txs, and an intent whose auction tick has not
+   * run yet. A null height is not a pending state: the receipt is still final. */
+  blockNumber: bigint | null;
   gasUsed: bigint;
 }
 
 /**
- * Poll `eth_getTransactionReceipt` until the tx is mined, then report whether it
- * executed or reverted. A hash from {@link sendRawTransaction} only means the
+ * Poll `eth_getTransactionReceipt` until a receipt exists, then report whether
+ * the tx executed or reverted. A hash from {@link sendRawTransaction} only means the
  * node accepted the tx into its pool — it is NOT yet confirmed. Await this to
  * know the on-chain outcome. Throws on timeout. Like the rest of this module
  * it's transport-only (raw JSON-RPC), so it needs no viem client.
@@ -539,14 +542,19 @@ export async function waitForReceipt(
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getTransactionReceipt", params: [hash] }),
     });
     const json = (await res.json()) as {
-      result?: { status: string; transactionHash: Hash; blockNumber: string; gasUsed: string } | null;
+      result?: {
+        status: string;
+        transactionHash: Hash;
+        blockNumber?: string | null;
+        gasUsed: string;
+      } | null;
     };
     const r = json.result;
     if (r) {
       return {
         status: r.status === "0x1" ? "success" : "reverted",
         transactionHash: r.transactionHash,
-        blockNumber: BigInt(r.blockNumber),
+        blockNumber: r.blockNumber == null ? null : BigInt(r.blockNumber),
         gasUsed: BigInt(r.gasUsed),
       };
     }

--- a/types/src/ledger/log.rs
+++ b/types/src/ledger/log.rs
@@ -20,7 +20,12 @@ use crate::{
 
 use super::Receipt;
 
-pub fn to_rpc_format(inner_log: Log, tx_hash: Hash) -> RPCLog {
+/// `log_index` is the log's position within its transaction, which is what
+/// identifies it: pod does not order a block's transactions, so there is no
+/// `transaction_index` to pair with, and `(tx_hash, log_index)` is a log's only
+/// unique key. It was `Some(0)` for every log, which made the logs of a
+/// multi-log transaction indistinguishable.
+pub fn to_rpc_format(inner_log: Log, tx_hash: Hash, log_index: u64) -> RPCLog {
     RPCLog {
         inner: inner_log,
         // Absent rather than fabricated, for the same reason as the receipt's
@@ -31,7 +36,7 @@ pub fn to_rpc_format(inner_log: Log, tx_hash: Hash) -> RPCLog {
         block_timestamp: None,
         transaction_hash: Some(tx_hash),
         transaction_index: None,
-        log_index: Some(0),
+        log_index: Some(log_index),
         removed: false,
     }
 }

--- a/types/src/ledger/log.rs
+++ b/types/src/ledger/log.rs
@@ -23,11 +23,14 @@ use super::Receipt;
 pub fn to_rpc_format(inner_log: Log, tx_hash: Hash) -> RPCLog {
     RPCLog {
         inner: inner_log,
-        block_hash: Some(Hash::default()),
-        block_number: Some(1),
+        // Absent rather than fabricated, for the same reason as the receipt's
+        // fields: a `Log` carries no height, and these were a zero hash and
+        // block 1 on every log ever returned. Stamped by whoever knows the block.
+        block_hash: None,
+        block_number: None,
         block_timestamp: None,
         transaction_hash: Some(tx_hash),
-        transaction_index: Some(0),
+        transaction_index: None,
         log_index: Some(0),
         removed: false,
     }

--- a/types/src/ledger/receipt.rs
+++ b/types/src/ledger/receipt.rs
@@ -114,10 +114,15 @@ impl From<Receipt> for TransactionReceipt {
                 },
             }),
             transaction_hash: val.tx_hash,
-            transaction_index: Some(0),
-            block_hash: Some(Hash::default()), // Need hash for tx confirmation on Metamask
-            block_number: Some(1),             // Need number of tx confirmation on Metamask
-            gas_used: val.actual_gas_used,     // Gas used by the transaction alone.
+            // A `Receipt` carries no height, so this conversion cannot know the
+            // block. Absent, not fabricated: these used to be `Some(0)`/`Some(1)`
+            // so MetaMask counted a transaction as confirmed, which meant every
+            // receipt pointed at a block that does not exist. The producer that
+            // knows the block stamps it afterwards.
+            transaction_index: None,
+            block_hash: None,
+            block_number: None,
+            gas_used: val.actual_gas_used, // Gas used by the transaction alone.
             effective_gas_price: val.max_fee_per_gas, // Use max_fee_per_gas for EIP-1559 transactions
             blob_gas_used: None,                      // This is none for non EIP-4844 transactions.
             blob_gas_price: None,                     // This is none for non EIP-4844 transactions.

--- a/types/src/ledger/receipt.rs
+++ b/types/src/ledger/receipt.rs
@@ -109,7 +109,8 @@ impl From<Receipt> for TransactionReceipt {
                     logs: val
                         .logs
                         .into_iter()
-                        .map(|l| log::to_rpc_format(l, val.tx_hash))
+                        .enumerate()
+                        .map(|(i, l)| log::to_rpc_format(l, val.tx_hash, i as u64))
                         .collect(),
                 },
             }),
@@ -118,7 +119,8 @@ impl From<Receipt> for TransactionReceipt {
             // block. Absent, not fabricated: these used to be `Some(0)`/`Some(1)`
             // so MetaMask counted a transaction as confirmed, which meant every
             // receipt pointed at a block that does not exist. The producer that
-            // knows the block stamps it afterwards.
+            // knows the block stamps the block fields afterwards; the index has
+            // nothing to stamp, since pod does not order a block's transactions.
             transaction_index: None,
             block_hash: None,
             block_number: None,

--- a/types/src/rpc/receipt.rs
+++ b/types/src/rpc/receipt.rs
@@ -44,13 +44,11 @@ impl ReceiptResponse for PodReceiptResponse {
     }
 
     fn block_hash(&self) -> Option<BlockHash> {
-        // todo
-        Some(BlockHash::default())
+        self.receipt.block_hash()
     }
 
     fn block_number(&self) -> Option<u64> {
-        // todo
-        None
+        self.receipt.block_number()
     }
 
     fn transaction_hash(&self) -> TxHash {
@@ -58,8 +56,7 @@ impl ReceiptResponse for PodReceiptResponse {
     }
 
     fn transaction_index(&self) -> Option<u64> {
-        // todo
-        None
+        self.receipt.transaction_index()
     }
 
     fn gas_used(&self) -> u64 {


### PR DESCRIPTION
Receipts and logs stop claiming a block they were never in, a position they never had, and an index they shared with every sibling.

## The block

`From<Receipt> for PodTransactionReceipt` filled `blockNumber` with `Some(1)`, `blockHash` with the zero hash and `transactionIndex` with `Some(0)`, commented as what MetaMask needs to count a transaction as confirmed. `log::to_rpc_format` did the same for every log. But a `Receipt` and a `Log` carry no height, so those were never anything but filler: every receipt and log the RPC has ever returned pointed at a block that does not exist, and a caller had no way to tell a real block from the placeholder. `PodReceiptResponse`'s `ReceiptResponse` impl compounded it — `block_hash()` returned the zero hash while `block_number()` and `transaction_index()` returned `None` and threw away the values the receipt already held.

The block fields are absent now, and the accessors delegate to the receipt. Whoever knows the block stamps it: on pod that is the node, which learns the height when a solution tick sequences the transaction.

This is the pod-sdk half of pod's phase 3a (ADR 0038, "solver ticks are blocks"), where an executed solution tick becomes a block with a sequential height and the `eth_` surface serves real blocks. The node cannot report a true height while the type it converts through overwrites it with 1.

Some transactions are genuinely in no block and always will be — `submitSolutions` produces blocks rather than sitting in one, recovery transactions are sequenced by nothing, and an intent whose auction tick has not run yet is not sequenced yet either. Null is the answer for those, not a pending state: the receipt is final either way.

Note the block is deliberately *not* being added to `Receipt` itself. `Receipt` is the certified object — `VerifiableLog::verify` checks the committee's signatures against it — and it is built at weak-consensus finality, before the tick that sequences the transaction exists. Inside `append_leaves` a block field would invalidate every certificate; outside it, it would be unsigned data riding on a signed struct, which is worse than absent. The verifiable path needs no receipt field: a block hash is `keccak(height || deadline_us || solution_tx_hash)` over agreed inputs, so a client verifies the solution transaction's certificate and recomputes the hash itself.

## The position

`transactionIndex` is absent permanently, not pending a real value. pod does not order the transactions within a block: a tick's transactions are a set, and each executed on its own at weak-consensus finality before the tick included it, so an index would assert an execution order the chain does not have. Nothing on pod consumes it either — neither `eth_getTransactionByBlockNumberAndIndex` nor its by-hash sibling is implemented.

## The log index

With no `transactionIndex`, `(transactionHash, logIndex)` is a log's only unique key — and `to_rpc_format` set `log_index: Some(0)` on every log, so the logs of a multi-log transaction were indistinguishable from each other. It takes the index now and the receipt conversion enumerates its logs. This also settles a disagreement: the node's `eth_getLogs` path already reported the real per-transaction index, so the same log had one index there and 0 in its receipt.

## Client-visible change

`waitForReceipt` did `BigInt(r.blockNumber)`, and `BigInt(null)` throws — it would have rejected for every receipt with no block. `TxReceipt.blockNumber` is `bigint | null` now, and `TxExplorer`'s `blockNumber`/`transactionIndex` likewise. Any consumer that read the old placeholders as proof of confirmation was reading a constant.

`to_rpc_format` gains a `log_index` parameter, which is a breaking signature change for any external caller. There is one caller in this repo and none in pod.

The three OpenAPI receipt fields document their null. `blockHash` needed an `allOf` wrapper — this file is OpenAPI 3.0, where siblings of a `$ref` are ignored.
