### PR TITLE
fix(ts-sdk): drop delisted markets on reconnect

### DIFF
--- a/ts-sdk/src/sync/sources.test.ts
+++ b/ts-sdk/src/sync/sources.test.ts
@@ -1,0 +1,54 @@
+import { expect, it, vi } from "vitest";
+
+import type { Market } from "../types/public.js";
+import { marketsSource, type SyncContext } from "./sources.js";
+
+const market = (id: `0x${string}`, name: string): Market => ({
+  id,
+  name,
+  type: "spot",
+  base: { address: "0x01", symbol: "B", name: "Base" },
+  quote: { address: "0x02", symbol: "Q", name: "Quote" },
+  tickPrecision: 1n,
+  lotSize: 1n,
+  maxLeverage: 1,
+  fundingWindowUs: 0,
+  makerFee: 0n,
+  takerFee: 0n,
+  auctionIntervalMs: 1_000,
+});
+
+it("removes a delisted market on a reconnect seed", async () => {
+  const a = market("0x01", "A/Q");
+  const b = market("0x02", "B/Q");
+  const markets = vi.fn()
+    .mockResolvedValueOnce([a, b])
+    .mockResolvedValueOnce([a, b])
+    .mockResolvedValueOnce([a]);
+  let onOpen: (() => void) | undefined;
+  const ws = {
+    on: (_event: string, fn: () => void) => { onOpen = fn; return () => {}; },
+    subscribe: () => ({ unsubscribe() {}, update() {}, resubscribe() {} }),
+  };
+  const ctx = {
+    rest: { markets, marketStats: vi.fn().mockResolvedValue({ markets: [] }) },
+    ws,
+    marketResyncMs: 0,
+    positionResyncMs: 0,
+  } as unknown as SyncContext;
+  let current: Market[] | undefined;
+  const stop = marketsSource(ctx)({
+    set: (value) => { current = value; },
+    update: () => {},
+    current: () => current,
+    fail: (error) => { throw error; },
+  });
+
+  await vi.waitFor(() => expect(current?.map((m) => m.id)).toEqual([a.id, b.id]));
+  onOpen?.(); // cold-open duplicate seed
+  await vi.waitFor(() => expect(markets).toHaveBeenCalledTimes(2));
+  onOpen?.(); // reconnect after B was delisted
+  await vi.waitFor(() => expect(current?.map((m) => m.id)).toEqual([a.id]));
+
+  stop();
+});

--- a/ts-sdk/src/sync/sources.ts
+++ b/ts-sdk/src/sync/sources.ts
@@ -126,22 +126,26 @@ export function marketsSource(
     // Last session's static list (never dynamics — those stay live-only):
     // seeded synchronously so market-keyed UI mounts without a round trip.
     // The REST seed below overwrites it field-for-field when it lands.
-    const fromCache = new Set<MarketId>();
+    const staticIds = new Set<MarketId>();
     try {
       const cached = marketsCache && parseCachedMarkets(marketsCache.get());
-      cached?.forEach((m, i) => { orderIndex.set(m.id, i); byId.set(m.id, m); fromCache.add(m.id); });
+      cached?.forEach((m, i) => { orderIndex.set(m.id, i); byId.set(m.id, m); staticIds.add(m.id); });
       if (byId.size) publish();
     } catch { /* absent/corrupt cache — plain cold start */ }
 
     const seedStatic = () => rest.markets().then((markets) => {
       if (!alive) return;
-      // Fresh static truth: drop cache-seeded markets that no longer exist,
-      // so a delisting can't outlive the first seed. (Dynamics-only entries
-      // buffered from the WS stream are untouched, as before.)
+      // Fresh static truth: drop previously listed markets that no longer
+      // exist, so a delisting cannot survive a reconnect seed. Dynamics-only
+      // entries buffered from the WS stream are deliberately untouched.
       const fresh = new Set(markets.map((m) => m.id));
-      for (const id of fromCache) if (!fresh.has(id)) { byId.delete(id); orderIndex.delete(id); }
-      fromCache.clear();
-      markets.forEach((m, i) => { orderIndex.set(m.id, i); byId.set(m.id, { ...byId.get(m.id), ...m }); });
+      for (const id of staticIds) if (!fresh.has(id)) { byId.delete(id); orderIndex.delete(id); }
+      staticIds.clear();
+      markets.forEach((m, i) => {
+        staticIds.add(m.id);
+        orderIndex.set(m.id, i);
+        byId.set(m.id, { ...byId.get(m.id), ...m });
+      });
       publish();
       try { marketsCache?.set(serializeMarkets(markets)); } catch { /* storage denied/full */ }
     }).catch((e) => { if (!byId.size) h.fail(e); });


### PR DESCRIPTION
## Summary

- track every market seen in the authoritative static list, not only cache-hydrated entries
- remove a previously listed market when a reconnect seed no longer returns it
- preserve dynamics-only entries buffered from the WebSocket until static metadata arrives

## Why

`marketsSource` cleared its set of cache-seeded IDs after the first REST response and never repopulated it. A market delisted later therefore survived every reconnect seed in `byId` and remained visible for the lifetime of the client.

The regression test covers the initial seed, the duplicate cold-open seed, and a later reconnect whose static list no longer contains one market.

## Verification

- `npm run typecheck`
- `npm test` — 12 files, 143 tests
- `npm run build`
