### PR TITLE
docs(orderbook): drop the retired pre-ioc submitOrder overload

### DIFF
--- a/doc/api-reference/applications-precompiles/orderbook.md
+++ b/doc/api-reference/applications-precompiles/orderbook.md
@@ -64,7 +64,6 @@ Combinations are checked when the intent is validated:
 | ------------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `submitOrder(bytes32,int256,uint256,uint8,uint128,uint128,uint8)`                      | `0x1e416275` | **Current.** The `flags` form; the only one that can request post-only.                                                              |
 | `submitOrder(bytes32,int256,uint256,uint8,uint128,uint128,bool,bool)`                  | `0x435f7e71` | Deprecated. The old `reduceOnly, ioc` pair, still accepted; equivalent to setting bit 0 from `reduceOnly` and bit 1 from `ioc`.                         |
-| `submitOrder(bytes32,int256,uint256,uint8,uint128,uint128,bool)`                       | `0xc06f0480` | Retired. The `reduceOnly`-only form, rejected for any `deadline` at or after the network's configured legacy cutoff.                 |
 
 The `flags` overload can only be decoded by nodes that ship it, so a client that must also work against a network running an older build can keep emitting the deprecated `bool, bool` form — it is accepted unchanged, and it simply cannot request post-only.
 
@@ -204,8 +203,6 @@ contract Orderbook {
      *         written against it still decodes. It cannot request POST_ONLY.
      *         Equivalent to the current form with bit 0 set from `reduceOnly`
      *         and bit 1 from `ioc`.
-     * @dev A third, retired overload — the same call without `ioc` — is rejected
-     *      for any `deadline` at or after the network's legacy cutoff.
      */
     function submitOrder(
         bytes32 orderbookId,


### PR DESCRIPTION
The pre-`ioc` `submitOrder` overload — `submitOrder(bytes32,int256,uint256,uint8,uint128,uint128,bool)` / `0xc06f0480` — has been removed from the orderbook precompile, so these docs are now wrong about it.

They described it as merely gated ("rejected for any `deadline` at or after the network's configured legacy cutoff"), implying a client could still reach it below some cutoff. Its declaration is gone: calldata bearing that selector decodes to no known call at all and is rejected at parse, on every network and at every deadline.

Removes the two places that mention it — its row in the selector table, and the `@dev` note in the Solidity interface block.

The two surviving overloads are untouched and their selectors did not move: `0x1e416275` (current, the `flags` form) and `0x435f7e71` (deprecated, the `reduceOnly, ioc` pair, still accepted).

Node-side change: podnetwork/pod#1442, merged as `960ed3e54`.
